### PR TITLE
Run CI with non-privileged account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
   node4:
     docker:
       - image: node:4
-      - user: node
+        user: node
     steps:
       - checkout
       - run:
@@ -97,28 +97,28 @@ jobs:
   node6:
     docker:
       - image: node:6
-      - user: node
+        user: node
     <<: *unit_tests
   node7:
     docker:
       - image: node:7
-      - user: node
+        user: node
     <<: *unit_tests
   node8:
     docker:
       - image: node:8
-      - user: node
+        user: node
     <<: *unit_tests
   node9:
     docker:
       - image: node:9
-      - user: node
+        user: node
     <<: *unit_tests
 
   lint:
     docker:
       - image: node:8
-      - user: node
+        user: node
     steps:
       - checkout
       - run:
@@ -133,7 +133,7 @@ jobs:
   docs:
     docker:
       - image: node:8
-      - user: node
+        user: node
     steps:
       - checkout
       - run:
@@ -146,7 +146,7 @@ jobs:
   system_tests:
     docker:
       - image: node:8
-      - user: node
+        user: node
     steps:
       - checkout
       - run:
@@ -172,7 +172,7 @@ jobs:
   publish_npm:
     docker:
       - image: node:8
-      - user: node
+        user: node
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,11 +124,16 @@ jobs:
       - run:
           name: Install modules and dependencies.
           command: |
+            mkdir -p /home/node/.npm-global
             npm install
             npm link
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Run linting.
           command: npm run lint
+          environment:
+            NPM_CONFIG_PREFIX: /home/node/.npm-global
 
   docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,13 @@ unit_tests: &unit_tests
     - checkout
     - run:
         name: Install modules and dependencies.
-        command: |
-          su node
-          npm install
+        command: npm install
     - run:
         name: Run unit tests.
-        command: |
-          su node
-          npm test
+        command: npm test
     - run:
         name: Submit coverage data to codecov.
-        command: |
-          su node
-          node_modules/.bin/codecov
+        command: node_modules/.bin/codecov
         when: always
 
 version: 2.0
@@ -87,118 +81,103 @@ jobs:
   node4:
     docker:
       - image: node:4
+      - user: node
     steps:
       - checkout
       - run:
           name: Install modules and dependencies.
-          command: |
-            su node
-            npm install --unsafe-perm
+          command: npm install --unsafe-perm
       - run:
           name: Run unit tests.
-          command: |
-            su node
-            npm test
+          command: npm test
       - run:
           name: Submit coverage data to codecov.
-          command: |
-            su node
-            node_modules/.bin/codecov
+          command: node_modules/.bin/codecov
           when: always
   node6:
     docker:
       - image: node:6
+      - user: node
     <<: *unit_tests
   node7:
     docker:
       - image: node:7
+      - user: node
     <<: *unit_tests
   node8:
     docker:
       - image: node:8
+      - user: node
     <<: *unit_tests
   node9:
     docker:
       - image: node:9
+      - user: node
     <<: *unit_tests
 
   lint:
     docker:
       - image: node:8
+      - user: node
     steps:
       - checkout
       - run:
           name: Install modules and dependencies.
           command: |
-            su node
             npm install
             npm link
       - run:
           name: Run linting.
-          command: |
-            su node
-            npm run lint
+          command: npm run lint
 
   docs:
     docker:
       - image: node:8
+      - user: node
     steps:
       - checkout
       - run:
           name: Install modules and dependencies.
-          command: |
-            su node
-            npm install
+          command: npm install
       - run:
           name: Build documentation.
-          command: |
-            su node
-            npm run docs
+          command: npm run docs
 
   system_tests:
     docker:
       - image: node:8
+      - user: node
     steps:
       - checkout
       - run:
           name: Decrypt credentials.
           command: |
-            su node
             openssl aes-256-cbc -d -in .circleci/key.json.enc \
                 -out .circleci/key.json \
                 -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
       - run:
           name: Install modules and dependencies.
-          command: |
-            su node
-            npm install
+          command: npm install
       - run:
           name: Run system tests.
-          command: |
-            su node
-            npm run system-test
+          command: npm run system-test
           environment:
             GCLOUD_PROJECT: long-door-651
             GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
       - run:
           name: Remove unencrypted key.
-          command: |
-            su node
-            rm .circleci/key.json
+          command: rm .circleci/key.json
           when: always
 
   publish_npm:
     docker:
       - image: node:8
+      - user: node
     steps:
       - checkout
       - run:
           name: Set NPM authentication.
-          command: |
-            su node
-            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
-          name: Publish the module to npm.
-          command: |
-           su node
-           npm publish
+         name: Publish the module to npm.
+         command: npm publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,19 @@ unit_tests: &unit_tests
     - checkout
     - run:
         name: Install modules and dependencies.
-        command: npm install
+        command: |
+          su node
+          npm install
     - run:
         name: Run unit tests.
-        command: npm test
+        command: |
+          su node
+          npm test
     - run:
         name: Submit coverage data to codecov.
-        command: node_modules/.bin/codecov
+        command: |
+          su node
+          node_modules/.bin/codecov
         when: always
 
 version: 2.0
@@ -85,13 +91,19 @@ jobs:
       - checkout
       - run:
           name: Install modules and dependencies.
-          command: npm install --unsafe-perm
+          command: |
+            su node
+            npm install --unsafe-perm
       - run:
           name: Run unit tests.
-          command: npm test
+          command: |
+            su node
+            npm test
       - run:
           name: Submit coverage data to codecov.
-          command: node_modules/.bin/codecov
+          command: |
+            su node
+            node_modules/.bin/codecov
           when: always
   node6:
     docker:
@@ -118,11 +130,14 @@ jobs:
       - run:
           name: Install modules and dependencies.
           command: |
+            su node
             npm install
             npm link
       - run:
           name: Run linting.
-          command: npm run lint
+          command: |
+            su node
+            npm run lint
 
   docs:
     docker:
@@ -131,10 +146,14 @@ jobs:
       - checkout
       - run:
           name: Install modules and dependencies.
-          command: npm install
+          command: |
+            su node
+            npm install
       - run:
           name: Build documentation.
-          command: npm run docs
+          command: |
+            su node
+            npm run docs
 
   system_tests:
     docker:
@@ -144,21 +163,28 @@ jobs:
       - run:
           name: Decrypt credentials.
           command: |
+            su node
             openssl aes-256-cbc -d -in .circleci/key.json.enc \
                 -out .circleci/key.json \
                 -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
       - run:
           name: Install modules and dependencies.
-          command: npm install
+          command: |
+            su node
+            npm install
       - run:
           name: Run system tests.
-          command: npm run system-test
+          command: |
+            su node
+            npm run system-test
           environment:
             GCLOUD_PROJECT: long-door-651
             GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
       - run:
           name: Remove unencrypted key.
-          command: rm .circleci/key.json
+          command: |
+            su node
+            rm .circleci/key.json
           when: always
 
   publish_npm:
@@ -168,7 +194,11 @@ jobs:
       - checkout
       - run:
           name: Set NPM authentication.
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          command: |
+            su node
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run:
-         name: Publish the module to npm.
-         command: npm publish
+          name: Publish the module to npm.
+          command: |
+           su node
+           npm publish


### PR DESCRIPTION
**TL;DR:** when CI tasks are run as root, each task takes ~1 minute more than if run with non-privileged account.

**Longer explanation:**
- `npm install` wants to install GRPC modules.
- there are two ways of installing GRPC modules: faster (download precompiled .tar.gz) and slower (compile from scratch).
- precompiled .tar.gz contains file with userid:groupid ownership set to 255363:5000.
- when tar is run as root, it tries to create directories and files with exactly same ownership.
- docker container in CircleCI runs on btrfs, on which the `chown(2)` call returns `EINVAL` when tar tries to set the ownership to unknown user and group.
- tar fails to unpack the archive, and node-pre-gyp starts building GRPC from source as a fallback.

Note that when tar is run as non-privileged user, it does not try to change files' ownership (because any such attempt would have failed obviously).

Possible solutions:
- ask authors of node-pre-gyp to untar the archive using `--no-same-owner` (setting ownership to whatever provided by .tar.gz author does not make any sense anyway, so why bother setting it). Unfortunately, they use some very outdated version of node.js tar package that does not support this setting so it might be not an easy fix.
- run our workflows as non-root user.

This PR implements the latter.