### PR TITLE
fix(docs): provide clarification re: gke vs. Kubernetes

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -1,5 +1,12 @@
 introduction: |-
-    > Node.js idiomatic client for [Kubernetes Engine][product-docs] cluster management.
+  > Node.js idiomatic client for [Kubernetes Engine][product-docs] cluster management.
 
-    [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/) is used for
-    building and managing container based applications, powered by the open source Kubernetes technology.
+  [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/) is used for
+  building and managing container based applications, powered by the open source Kubernetes technology.
+body: |-
+  `@google-cloud/container` provides a high level API for creating and managing
+  [Google Kubernetes Engine](https://cloud.google.com/gke) clusters on Google Cloud.
+
+  To run commands against the clusters created, you will need to use the
+  [Kubernetes API](https://kubernetes.io/docs/reference/using-api/api-overview/)
+  (and the associated kubectl command-line interface).

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -4,6 +4,9 @@ introduction: |-
   [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/) is used for
   building and managing container based applications, powered by the open source Kubernetes technology.
 body: |-
+
+  ## Relationship to Kubernetes
+
   `@google-cloud/container` provides a high level API for creating and managing
   [Google Kubernetes Engine](https://cloud.google.com/gke) clusters on Google Cloud.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ npm install @google-cloud/container
   quickstart();
 
 ```
+
+## Relationship to Kubernetes
+
 `@google-cloud/container` provides a high level API for creating and managing
 [Google Kubernetes Engine](https://cloud.google.com/gke) clusters on Google Cloud.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ npm install @google-cloud/container
   quickstart();
 
 ```
+`@google-cloud/container` provides a high level API for creating and managing
+[Google Kubernetes Engine](https://cloud.google.com/gke) clusters on Google Cloud.
 
+To run commands against the clusters created, you will need to use the
+[Kubernetes API](https://kubernetes.io/docs/reference/using-api/api-overview/)
+(and the associated kubectl command-line interface).
 
 
 ## Samples

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,19 +1,19 @@
 {
-  "updateTime": "2019-06-05T14:14:12.022698Z",
+  "updateTime": "2019-06-14T21:35:54.740723Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "0.23.1",
-        "dockerImage": "googleapis/artman@sha256:9d5cae1454da64ac3a87028f8ef486b04889e351c83bb95e83b8fab3959faed0"
+        "version": "0.26.0",
+        "dockerImage": "googleapis/artman@sha256:6db0735b0d3beec5b887153a2a7c7411fc7bb53f73f6f389a822096bd14a3a15"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "47c142a7cecc6efc9f6f8af804b8be55392b795b",
-        "internalRef": "251635729"
+        "sha": "afa7c03170dfeacb3399079f8c955faf14eb4a67",
+        "internalRef": "253272509"
       }
     },
     {

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-06-14T21:35:54.740723Z",
+  "updateTime": "2019-06-14T21:54:48.589158Z",
   "sources": [
     {
       "generator": {


### PR DESCRIPTION
based on @bigdoods suggestion in #145, clarifies the relationship between `@google-cloud/container` and Kubernetes.

Thanks for the great suggestion!