### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs @googleapis/cicd


### PR DESCRIPTION
fix #406 
Updating codeowners to include cicd team