### PR TITLE
docs(samples): add usage samples to show handling of LRO response Operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Samples are in the [`samples/`](https://github.com/googleapis/nodejs-cloud-conta
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
+| Create_cluster | [source code](https://github.com/googleapis/nodejs-cloud-container/blob/main/samples/create_cluster.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-cloud-container&page=editor&open_in_editor=samples/create_cluster.js,samples/README.md) |
+| Delete_cluster | [source code](https://github.com/googleapis/nodejs-cloud-container/blob/main/samples/delete_cluster.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-cloud-container&page=editor&open_in_editor=samples/delete_cluster.js,samples/README.md) |
 | Quickstart | [source code](https://github.com/googleapis/nodejs-cloud-container/blob/main/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-cloud-container&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
 
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ async function main() {
     };
 
     const [response] = await client.listClusters(request);
-    console.log('Clusters:');
-    console.log(response);
+    console.log('Clusters: ', response);
   }
   quickstart();
 }

--- a/README.md
+++ b/README.md
@@ -60,24 +60,30 @@ npm install @google-cloud/container
 ### Using the client library
 
 ```javascript
-const container = require('@google-cloud/container');
+'use strict';
 
-// Create the Cluster Manager Client
-const client = new container.v1.ClusterManagerClient();
+async function main() {
+  const container = require('@google-cloud/container');
 
-async function quickstart() {
-  const zone = 'us-central1-a';
-  const projectId = await client.getProjectId();
-  const request = {
-    projectId: projectId,
-    zone: zone,
-  };
+  // Create the Cluster Manager Client
+  const client = new container.v1.ClusterManagerClient();
 
-  const [response] = await client.listClusters(request);
-  console.log('Clusters:');
-  console.log(response);
+  async function quickstart() {
+    const zone = 'us-central1-a';
+    const projectId = await client.getProjectId();
+    const request = {
+      projectId: projectId,
+      zone: zone,
+    };
+
+    const [response] = await client.listClusters(request);
+    console.log('Clusters:');
+    console.log(response);
+  }
+  quickstart();
 }
-quickstart();
+
+main().catch(console.error);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ npm install @google-cloud/container
 ### Using the client library
 
 ```javascript
-'use strict';
-
 async function main() {
   const container = require('@google-cloud/container');
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "google-gax": "^2.24.1"
+    "google-gax": "^2.24.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "precompile": "gts clean"
   },
   "dependencies": {
-    "google-gax": "^2.24.1",
-    "uuid": "^8.3.2"
+    "google-gax": "^2.24.1"
   },
   "devDependencies": {
     "@types/mocha": "^8.0.0",

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,6 +15,8 @@ building and managing container based applications, powered by the open source K
 
 * [Before you begin](#before-you-begin)
 * [Samples](#samples)
+  * [Create_cluster](#create_cluster)
+  * [Delete_cluster](#delete_cluster)
   * [Quickstart](#quickstart)
 
 ## Before you begin
@@ -29,6 +31,40 @@ Before running the samples, make sure you've followed the steps outlined in
 `cd ..`
 
 ## Samples
+
+
+
+### Create_cluster
+
+View the [source code](https://github.com/googleapis/nodejs-cloud-container/blob/main/samples/create_cluster.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-cloud-container&page=editor&open_in_editor=samples/create_cluster.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/create_cluster.js`
+
+
+-----
+
+
+
+
+### Delete_cluster
+
+View the [source code](https://github.com/googleapis/nodejs-cloud-container/blob/main/samples/delete_cluster.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-cloud-container&page=editor&open_in_editor=samples/delete_cluster.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/delete_cluster.js`
+
+
+-----
+
 
 
 

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -39,16 +39,16 @@ let prevFibonacciDelay = 0;
  * @returns a Promise that wraps the status check function
  */
 const checkOpStatus = (client, opId) => {
-    const getOpFn = async (resolve, reject) => {
-        const [longRunningOp] = await client.getOperation({ name: opId });
-        const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
-        if (longRunningOp.status === DONE) {
-            resolve('Cluster creation completed.');
-        } else {
-            reject('Cluster creation not complete.');
-        }
-    };
-    return new Promise(getOpFn);
+  const getOpFn = async (resolve, reject) => {
+    const [longRunningOp] = await client.getOperation({name: opId});
+    const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
+    if (longRunningOp.status === DONE) {
+      resolve('Cluster creation completed.');
+    } else {
+      reject('Cluster creation not complete.');
+    }
+  };
+  return new Promise(getOpFn);
 };
 
 /**
@@ -78,31 +78,31 @@ function getFibonacciDelay(delay) {
  * @param {number} retryCount the current number of retried attempted
  */
 function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
-    checkOpStatus(client, opId)
-        .then(status => {
-            // success scenario
-            console.log(status);
-        })
-        .catch(status => {
-            // fail (not yet complete) scenario
-            if (retryCount < maxtries) {
-                console.log(`${status} will try after ${delay / 1000}s delay...`);
-                const newDelay = getFibonacciDelay(delay);
-                setTimeout(
-                    () =>
-                        checkStatusWithRetry(
-                            client,
-                            opId,
-                            newDelay,
-                            maxtries,
-                            retryCount + 1
-                        ),
-                    delay
-                );
-            } else {
-                console.log(`${status} max retries reached, giving up.`);
-            }
-        });
+  checkOpStatus(client, opId)
+    .then(status => {
+      // success scenario
+      console.log(status);
+    })
+    .catch(status => {
+      // fail (not yet complete) scenario
+      if (retryCount < maxtries) {
+        console.log(`${status} will try after ${delay / 1000}s delay...`);
+        const newDelay = getFibonacciDelay(delay);
+        setTimeout(
+          () =>
+            checkStatusWithRetry(
+              client,
+              opId,
+              newDelay,
+              maxtries,
+              retryCount + 1
+            ),
+          delay
+        );
+      } else {
+        console.log(`${status} max retries reached, giving up.`);
+      }
+    });
 }
 
 /**
@@ -116,26 +116,26 @@ function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
  * @param {string} clusterName the name to be given to the new cluster
  */
 async function createCluster(gcpZone, clusterName) {
-    // Create the Cluster Manager Client
-    const client = new container.v1.ClusterManagerClient();
-    const gcpProject = await client.getProjectId();
-    const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
-    const request = {
-        parent: clusterLocation,
-        cluster: {
-            name: clusterName,
-            initialNodeCount: 2,
-            nodeConfig: {
-                machineType: 'e2-standard-2',
-            },
-        },
-    };
-    // invoke the create cluster API using the client
-    const [createOperation] = await client.createCluster(request);
-    // extract the unique identifier of the operation to checkback status
-    const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
-    // schedule polling to check if the creation operation is completed
-    checkStatusWithRetry(client, opIdentifier, 1000, 20);
+  // Create the Cluster Manager Client
+  const client = new container.v1.ClusterManagerClient();
+  const gcpProject = await client.getProjectId();
+  const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
+  const request = {
+    parent: clusterLocation,
+    cluster: {
+      name: clusterName,
+      initialNodeCount: 2,
+      nodeConfig: {
+        machineType: 'e2-standard-2',
+      },
+    },
+  };
+  // invoke the create cluster API using the client
+  const [createOperation] = await client.createCluster(request);
+  // extract the unique identifier of the operation to checkback status
+  const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
+  // schedule polling to check if the creation operation is completed
+  checkStatusWithRetry(client, opIdentifier, 1000, 20);
 }
 
 /**
@@ -146,16 +146,16 @@ async function createCluster(gcpZone, clusterName) {
  * > node create_cluster.js --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
  */
 async function main() {
-    if (!args.zone) {
-        console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
-        exit(1);
-    }
-    if (!args.name) {
-        console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
-        exit(1);
-    }
-    // Create a new GKE cluster
-    createCluster(args.zone, args.name);
+  if (!args.zone) {
+    console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
+    exit(1);
+  }
+  if (!args.name) {
+    console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
+    exit(1);
+  }
+  // Create a new GKE cluster
+  createCluster(args.zone, args.name);
 }
 
 // program starts here

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -1,0 +1,157 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// load the google-cloud nodejs library for GKE
+const container = require('@google-cloud/container');
+const args = require('yargs').argv;
+const { exit } = require('process');
+
+// assign the operation status enum to a variable for easy access
+const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+var prevFibonacciDelay = 0;
+
+/**
+ * This function define a function that calls the `getOperation` API to fetch
+ * the details of a specific operation and checks for its completion. It returns
+ * the defined function wrapped in a Promise. The function it defines takes in a
+ * google cloud client along with the unique identifier of the operation we want
+ * to check.
+ * 
+ * The response to the defined function is a 'Promise.reject' if the operation
+ * is still not complete and a 'Promise.resolve' if it is complete. 
+ * 
+ * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} opId the unique identifier of the operation we want to check
+ * @returns a Promise that wraps the status check function
+ */
+const checkOpStatus = (client, opId) => {
+    const getOpFn = async (resolve, reject) => {
+        const [longRunningOp] = await client.getOperation({ name: opId });
+        const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
+        if (longRunningOp.status === DONE) {
+            resolve('Cluster creation completed.');
+        } else {
+            reject('Cluster creation not complete.');
+        }
+    }
+    return new Promise(getOpFn);
+}
+
+/**
+ * A simple function that returns the next number in a fibonacci sequence that
+ * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
+ * as f(n - 2). This function is used to simulate a fibonacci sequence for the
+ * backing off (delay) time used when retrying.
+ * 
+ * @param {number} delay the previous delay in the sequence
+ * @returns the next delay before retrying
+ */
+function getFibonacciDelay(delay) {
+    const newDelay = prevFibonacciDelay + delay;
+    prevFibonacciDelay = delay;
+    return newDelay;
+}
+
+/**
+ * This method calls the Promise function (`checkOpStatus()`) to check the
+ * status of an operation and schedules a retry if the operation is still not
+ * completed. The retry delay is modelled as a fibonacci sequence.  
+ * 
+ * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} opId the unique identifier of the operation we want to check
+ * @param {number} delay the delay with which the next retry is to be scheduled
+ * @param {number} maxtries maximum number of retry attempts to go before giving up
+ * @param {number} retryCount the current number of retried attempted
+ */
+function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
+    checkOpStatus(client, opId)
+        .then((status) => {
+            // success scenario
+            console.log(status);
+        })
+        .catch((status) => {
+             // fail (not yet complete) scenario
+            if (retryCount < maxtries) {
+                console.log(`${status} will try after ${delay / 1000}s delay...`);
+                const newDelay = getFibonacciDelay(delay);
+                setTimeout(
+                    () => checkStatusWithRetry(client, opId, newDelay, maxtries, retryCount + 1),
+                    delay);
+            } else {
+                console.log(`${status} max retries reached, giving up.`);
+            }
+        })
+}
+
+/**
+ * This method creates a GKE cluster using the given client in the GCP project
+ * and zone indicated by the `gcpProject` and `gcpZone` parameters. The last
+ * argment is used as the name given to the newly created cluster.
+ * 
+ * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} gcpProject the GCP project where the cluster is to be created
+ * @param {string} gcpZone the GCP zone where the cluster is to be created
+ * @param {string} clusterName the name to be given to the new cluster
+ */
+async function createCluster(client, gcpProject, gcpZone, clusterName) {
+    const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
+    const request = {
+        parent: clusterLocation,
+        cluster: {
+            name: clusterName,
+            initialNodeCount: 2,
+            nodeConfig: {
+                machineType: 'e2-standard-2'
+            },
+        },
+    };
+    // invoke the create cluster API using the client
+    const [createOperation] = await client.createCluster(request);
+    // extract the unique identifier of the operation to checkback status
+    const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
+    // schedule polling to check if the creation operation is completed
+    checkStatusWithRetry(client, opIdentifier, 1000, 20);
+}
+
+/**
+ * Entrypoint into the sample. Expects three arguments to the program.
+ * 1. The GCP Project to use
+ * 2. The GCP Zone to use
+ * 3. The name to give to the new GKE cluster
+ * 
+ * > node create_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
+ */
+async function main() {
+    if (!!!args.project) {
+        console.log('Missing project argument. (e.g. --project=test_project)');
+        exit(1);
+    }
+    if (!!!args.zone) {
+        console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
+        exit(1);
+    }
+    if (!!!args.name) {
+        console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
+        exit(1);
+    }
+    // Create the Cluster Manager Client
+    const client = new container.v1.ClusterManagerClient();
+    // Create a new GKE cluster
+    createCluster(client, args.project, args.zone, args.name);
+}
+
+// program starts here
+main().catch(console.error);

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -14,157 +14,156 @@
 
 'use strict';
 
-// [START gke_create_cluster]
-
-// load the google-cloud nodejs library for GKE
-const container = require('@google-cloud/container');
-const args = require('yargs').argv;
-const {exit} = require('process');
-
-// assign the operation status enum to a variable for easy access
-const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
-let prevFibonacciDelay = 0;
-
-/**
- * This function define a function that calls the `getOperation` API to fetch
- * the details of a specific operation and checks for its completion. It returns
- * the defined function wrapped in a Promise. The function it defines takes in a
- * google cloud client along with the unique identifier of the operation we want
- * to check.
- *
- * The response to the defined function is a 'Promise.reject' if the operation
- * is still not complete and a 'Promise.resolve' if it is complete.
- *
- * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
- * @param {string} opId the unique identifier of the operation we want to check
- * @returns a Promise that wraps the status check function
- */
-const checkOpStatus = (client, opId) => {
-  const getOpFn = async (resolve, reject) => {
-    const [longRunningOp] = await client.getOperation({name: opId});
-    const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
-    if (longRunningOp.status === DONE) {
-      resolve('Cluster creation completed.');
-    } else {
-      reject('Cluster creation not complete.');
-    }
-  };
-  return new Promise(getOpFn);
-};
-
-/**
- * A simple function that returns the next number in a fibonacci sequence that
- * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
- * as f(n - 2). This function is used to simulate a fibonacci sequence for the
- * backing off (delay) time used when retrying.
- *
- * @param {number} delay the previous delay in the sequence
- * @returns the next delay before retrying
- */
-function getFibonacciDelay(delay) {
-  const newDelay = prevFibonacciDelay + delay;
-  prevFibonacciDelay = delay;
-  return newDelay;
-}
-
-/**
- * This method calls the Promise function (`checkOpStatus()`) to check the
- * status of an operation and schedules a retry if the operation is still not
- * completed. The retry delay is modelled as a fibonacci sequence.
- *
- * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
- * @param {string} opId the unique identifier of the operation we want to check
- * @param {number} delay the delay with which the next retry is to be scheduled
- * @param {number} maxtries maximum number of retry attempts to go before giving up
- * @param {number} retryCount the current number of retried attempted
- */
-function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
-  checkOpStatus(client, opId)
-    .then(status => {
-      // success scenario
-      console.log(status);
-    })
-    .catch(status => {
-      // fail (not yet complete) scenario
-      if (retryCount < maxtries) {
-        console.log(`${status} will try after ${delay / 1000}s delay...`);
-        const newDelay = getFibonacciDelay(delay);
-        setTimeout(
-          () =>
-            checkStatusWithRetry(
-              client,
-              opId,
-              newDelay,
-              maxtries,
-              retryCount + 1
-            ),
-          delay
-        );
-      } else {
-        console.log(`${status} max retries reached, giving up.`);
-      }
-    });
-}
-
-/**
- * This method creates a GKE cluster using the given client in the GCP project
- * and zone indicated by the `gcpProject` and `gcpZone` parameters. The last
- * argment is used as the name given to the newly created cluster.
- *
- * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
- * @param {string} gcpProject the GCP project where the cluster is to be created
- * @param {string} gcpZone the GCP zone where the cluster is to be created
- * @param {string} clusterName the name to be given to the new cluster
- */
-async function createCluster(gcpZone, clusterName, networkName) {
-  // Create the Cluster Manager Client
-  const client = new container.v1.ClusterManagerClient();
-  const gcpProject = await client.getProjectId();
-  const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
-  const request = {
-    parent: clusterLocation,
-    cluster: {
-      name: clusterName,
-      network: networkName,
-      initialNodeCount: 2,
-      nodeConfig: {
-        machineType: 'e2-standard-2',
-      },
-    },
-  };
-  // invoke the create cluster API using the client
-  const [createOperation] = await client.createCluster(request);
-  // extract the unique identifier of the operation to checkback status
-  const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
-  // schedule polling to check if the creation operation is completed
-  checkStatusWithRetry(client, opIdentifier, 1000, 20);
-}
-
 /**
  * Entrypoint into the sample. Expects three arguments to the program.
- * 1. The GCP Zone to use
- * 2. The name to give to the new GKE cluster
+ * 1. The name to give to the new GKE cluster
+ * 2. The GCP Zone to use
+ * 3. The GCP VPC Network to use
  *
- * > node create_cluster.js --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
+ * > node create_cluster.js <CLUSTER_NAME> <GCP_ZONE> <GCP_VPC_NETWORK>
  */
-async function main() {
-  if (!args.name || !args.zone) {
-    console.log(
-      'Missing argument. Required name and zone (e.g. --name=gke-cluster, --zone=us-west1-a)'
-    );
-    exit(1);
+async function main(
+  clusterName = 'Name to be given to the GKE cluster',
+  clusterZone = 'Location where the cluster is to be created',
+  clusterNetwork = 'VPC network to which the cluster nodes will be attached to'
+) {
+  // [START gke_create_cluster]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const clusterName = 'sample-gke-cluster';
+  // const clusterZone = 'us-central1-c';
+  // const clusterNetwork = 'default'
+
+  // load the google-cloud nodejs library for GKE
+  const container = require('@google-cloud/container');
+  // assign the operation status enum to a variable for easy access
+  const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+  // define fib(0) for the fibonacci series we use for delay calculation
+  let prevFibonacciDelay = 0;
+
+  /**
+   * This function calls the `getOperation` API to fetch the details of a specific
+   * operation and checks for its completion. It returns the defined function
+   * wrapped in a Promise. The function it defines takes in a google cloud client
+   * along with the unique identifier of the operation we want to check.
+   *
+   * The response to the defined function is a 'Promise.reject' if the operation
+   * is still not complete and a 'Promise.resolve' if it is complete.
+   *
+   * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
+   * @param {string} opId the unique identifier of the operation we want to check
+   * @returns a Promise that wraps the status check function
+   */
+  const checkOpStatus = (client, opId) => {
+    const getOpFn = async (resolve, reject) => {
+      const [longRunningOp] = await client.getOperation({name: opId});
+      const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
+      if (longRunningOp.status === DONE) {
+        resolve('Cluster creation completed.');
+      } else {
+        reject('Cluster creation not complete.');
+      }
+    };
+    return new Promise(getOpFn);
+  };
+
+  /**
+   * This method calls the Promise function (`checkOpStatus()`) to check the
+   * status of an operation and schedules a retry if the operation is still not
+   * completed. The retry delay is modelled as a fibonacci sequence.
+   *
+   * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+   * @param {string} opId the unique identifier of the operation we want to check
+   * @param {number} delay the delay with which the next retry is to be scheduled
+   * @param {number} maxtries maximum number of retry attempts to go before giving up
+   * @param {number} retryCount the current number of retried attempted
+   */
+  function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
+    checkOpStatus(client, opId)
+      .then(status => {
+        // success scenario
+        console.log(status);
+      })
+      .catch(status => {
+        // fail (not yet complete) scenario
+        if (retryCount < maxtries) {
+          console.log(`${status} will try after ${delay / 1000}s delay...`);
+          const newDelay = getFibonacciDelay(delay);
+          setTimeout(
+            () =>
+              checkStatusWithRetry(
+                client,
+                opId,
+                newDelay,
+                maxtries,
+                retryCount + 1
+              ),
+            delay
+          );
+        } else {
+          console.log(`${status} max retries reached, giving up.`);
+        }
+      });
   }
-  // use the default network if no network is provided
-  let network = 'default';
-  if (args.network) {
-    network = args.network;
-  } else {
-    console.log(`No network provided; using ${network} network`);
+
+  /**
+   * A simple function that returns the next number in a fibonacci sequence that
+   * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
+   * as f(n - 2). This function is used to simulate a fibonacci sequence for the
+   * backing off (delay) time used when retrying.
+   *
+   * @param {number} delay the previous delay in the sequence
+   * @returns the next delay before retrying
+   */
+  function getFibonacciDelay(delay) {
+    const newDelay = prevFibonacciDelay + delay;
+    prevFibonacciDelay = delay;
+    return newDelay;
   }
+
+  /**
+   * This method creates a GKE cluster with the name indicated by `clusterName`
+   * in the zone indicated by `clusterZone`. The cluster will use the network
+   * pointed to by `clusterNetwork`.
+   */
+  async function createCluster() {
+    // Create the Cluster Manager Client
+    const client = new container.v1.ClusterManagerClient();
+    const gcpProject = await client.getProjectId();
+    const clusterLocation = `projects/${gcpProject}/locations/${clusterZone}`;
+    const request = {
+      parent: clusterLocation,
+      cluster: {
+        name: clusterName,
+        network: clusterNetwork,
+        initialNodeCount: 2,
+        nodeConfig: {
+          machineType: 'e2-standard-2',
+        },
+      },
+    };
+    // invoke the create cluster API using the client
+    const [createOperation] = await client.createCluster(request);
+    // extract the unique identifier of the operation to checkback status
+    const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
+    // initial delay before retry in milli seconds
+    const retryDelay = 1000;
+    // maximum number of times to check for operation completion before giving up
+    const maxRetryCount = 20;
+    // schedule polling to check if the creation operation is completed
+    checkStatusWithRetry(client, opIdentifier, retryDelay, maxRetryCount);
+  }
+
   // Create a new GKE cluster
-  createCluster(args.zone, args.name, network);
+  createCluster();
+  // [END gke_create_cluster]
 }
 
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+
 // program starts here
-main().catch(console.error);
-// [END gke_create_cluster]
+main(...process.argv.slice(2));

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START gke_create_cluster]
 'use strict';
 
 // load the google-cloud nodejs library for GKE
@@ -21,7 +22,7 @@ const { exit } = require('process');
 
 // assign the operation status enum to a variable for easy access
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
-var prevFibonacciDelay = 0;
+let prevFibonacciDelay = 0;
 
 /**
  * This function define a function that calls the `getOperation` API to fetch
@@ -29,10 +30,10 @@ var prevFibonacciDelay = 0;
  * the defined function wrapped in a Promise. The function it defines takes in a
  * google cloud client along with the unique identifier of the operation we want
  * to check.
- * 
+ *
  * The response to the defined function is a 'Promise.reject' if the operation
- * is still not complete and a 'Promise.resolve' if it is complete. 
- * 
+ * is still not complete and a 'Promise.resolve' if it is complete.
+ *
  * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} opId the unique identifier of the operation we want to check
  * @returns a Promise that wraps the status check function
@@ -46,16 +47,16 @@ const checkOpStatus = (client, opId) => {
         } else {
             reject('Cluster creation not complete.');
         }
-    }
+    };
     return new Promise(getOpFn);
-}
+};
 
 /**
  * A simple function that returns the next number in a fibonacci sequence that
  * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
  * as f(n - 2). This function is used to simulate a fibonacci sequence for the
  * backing off (delay) time used when retrying.
- * 
+ *
  * @param {number} delay the previous delay in the sequence
  * @returns the next delay before retrying
  */
@@ -68,8 +69,8 @@ function getFibonacciDelay(delay) {
 /**
  * This method calls the Promise function (`checkOpStatus()`) to check the
  * status of an operation and schedules a retry if the operation is still not
- * completed. The retry delay is modelled as a fibonacci sequence.  
- * 
+ * completed. The retry delay is modelled as a fibonacci sequence.
+ *
  * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} opId the unique identifier of the operation we want to check
  * @param {number} delay the delay with which the next retry is to be scheduled
@@ -78,35 +79,46 @@ function getFibonacciDelay(delay) {
  */
 function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
     checkOpStatus(client, opId)
-        .then((status) => {
+        .then(status => {
             // success scenario
             console.log(status);
         })
-        .catch((status) => {
-             // fail (not yet complete) scenario
+        .catch(status => {
+            // fail (not yet complete) scenario
             if (retryCount < maxtries) {
                 console.log(`${status} will try after ${delay / 1000}s delay...`);
                 const newDelay = getFibonacciDelay(delay);
                 setTimeout(
-                    () => checkStatusWithRetry(client, opId, newDelay, maxtries, retryCount + 1),
-                    delay);
+                    () =>
+                        checkStatusWithRetry(
+                            client,
+                            opId,
+                            newDelay,
+                            maxtries,
+                            retryCount + 1
+                        ),
+                    delay
+                );
             } else {
                 console.log(`${status} max retries reached, giving up.`);
             }
-        })
+        });
 }
 
 /**
  * This method creates a GKE cluster using the given client in the GCP project
  * and zone indicated by the `gcpProject` and `gcpZone` parameters. The last
  * argment is used as the name given to the newly created cluster.
- * 
+ *
  * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} gcpProject the GCP project where the cluster is to be created
  * @param {string} gcpZone the GCP zone where the cluster is to be created
  * @param {string} clusterName the name to be given to the new cluster
  */
-async function createCluster(client, gcpProject, gcpZone, clusterName) {
+async function createCluster(gcpZone, clusterName) {
+    // Create the Cluster Manager Client
+    const client = new container.v1.ClusterManagerClient();
+    const gcpProject = await client.getProjectId();
     const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
     const request = {
         parent: clusterLocation,
@@ -114,7 +126,7 @@ async function createCluster(client, gcpProject, gcpZone, clusterName) {
             name: clusterName,
             initialNodeCount: 2,
             nodeConfig: {
-                machineType: 'e2-standard-2'
+                machineType: 'e2-standard-2',
             },
         },
     };
@@ -128,30 +140,24 @@ async function createCluster(client, gcpProject, gcpZone, clusterName) {
 
 /**
  * Entrypoint into the sample. Expects three arguments to the program.
- * 1. The GCP Project to use
- * 2. The GCP Zone to use
- * 3. The name to give to the new GKE cluster
- * 
- * > node create_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
+ * 1. The GCP Zone to use
+ * 2. The name to give to the new GKE cluster
+ *
+ * > node create_cluster.js --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
  */
 async function main() {
-    if (!!!args.project) {
-        console.log('Missing project argument. (e.g. --project=test_project)');
-        exit(1);
-    }
-    if (!!!args.zone) {
+    if (!args.zone) {
         console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
         exit(1);
     }
-    if (!!!args.name) {
+    if (!args.name) {
         console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
         exit(1);
     }
-    // Create the Cluster Manager Client
-    const client = new container.v1.ClusterManagerClient();
     // Create a new GKE cluster
-    createCluster(client, args.project, args.zone, args.name);
+    createCluster(args.zone, args.name);
 }
 
 // program starts here
 main().catch(console.error);
+// [END gke_create_cluster]

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START gke_create_cluster]
 'use strict';
+
+// [START gke_create_cluster]
 
 // load the google-cloud nodejs library for GKE
 const container = require('@google-cloud/container');
 const args = require('yargs').argv;
-const {exit} = require('process');
+const { exit } = require('process');
 
 // assign the operation status enum to a variable for easy access
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
@@ -61,9 +62,9 @@ const checkOpStatus = (client, opId) => {
  * @returns the next delay before retrying
  */
 function getFibonacciDelay(delay) {
-  const newDelay = prevFibonacciDelay + delay;
-  prevFibonacciDelay = delay;
-  return newDelay;
+    const newDelay = prevFibonacciDelay + delay;
+    prevFibonacciDelay = delay;
+    return newDelay;
 }
 
 /**

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -39,7 +39,6 @@ let prevFibonacciDelay = 0;
  * @returns a Promise that wraps the status check function
  */
 const checkOpStatus = (client, opId) => {
-<<<<<<< HEAD
     const getOpFn = async (resolve, reject) => {
         const [longRunningOp] = await client.getOperation({ name: opId });
         const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
@@ -50,18 +49,6 @@ const checkOpStatus = (client, opId) => {
         }
     };
     return new Promise(getOpFn);
-=======
-  const getOpFn = async (resolve, reject) => {
-    const [longRunningOp] = await client.getOperation({name: opId});
-    const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
-    if (longRunningOp.status === DONE) {
-      resolve('Cluster creation completed.');
-    } else {
-      reject('Cluster creation not complete.');
-    }
-  };
-  return new Promise(getOpFn);
->>>>>>> b5cf5a7198f56d8ee400b1c61921372cd1b27cf3
 };
 
 /**

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -17,11 +17,11 @@
 // load the google-cloud nodejs library for GKE
 const container = require('@google-cloud/container');
 const args = require('yargs').argv;
-const { exit } = require('process');
+const {exit} = require('process');
 
 // assign the operation status enum to a variable for easy access
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
-var prevFibonacciDelay = 0;
+let prevFibonacciDelay = 0;
 
 /**
  * This function define a function that calls the `getOperation` API to fetch
@@ -29,47 +29,47 @@ var prevFibonacciDelay = 0;
  * the defined function wrapped in a Promise. The function it defines takes in a
  * google cloud client along with the unique identifier of the operation we want
  * to check.
- * 
+ *
  * The response to the defined function is a 'Promise.reject' if the operation
- * is still not complete and a 'Promise.resolve' if it is complete. 
- * 
+ * is still not complete and a 'Promise.resolve' if it is complete.
+ *
  * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} opId the unique identifier of the operation we want to check
  * @returns a Promise that wraps the status check function
  */
 const checkOpStatus = (client, opId) => {
-    const getOpFn = async (resolve, reject) => {
-        const [longRunningOp] = await client.getOperation({ name: opId });
-        const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
-        if (longRunningOp.status === DONE) {
-            resolve('Cluster creation completed.');
-        } else {
-            reject('Cluster creation not complete.');
-        }
+  const getOpFn = async (resolve, reject) => {
+    const [longRunningOp] = await client.getOperation({name: opId});
+    const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
+    if (longRunningOp.status === DONE) {
+      resolve('Cluster creation completed.');
+    } else {
+      reject('Cluster creation not complete.');
     }
-    return new Promise(getOpFn);
-}
+  };
+  return new Promise(getOpFn);
+};
 
 /**
  * A simple function that returns the next number in a fibonacci sequence that
  * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
  * as f(n - 2). This function is used to simulate a fibonacci sequence for the
  * backing off (delay) time used when retrying.
- * 
+ *
  * @param {number} delay the previous delay in the sequence
  * @returns the next delay before retrying
  */
 function getFibonacciDelay(delay) {
-    const newDelay = prevFibonacciDelay + delay;
-    prevFibonacciDelay = delay;
-    return newDelay;
+  const newDelay = prevFibonacciDelay + delay;
+  prevFibonacciDelay = delay;
+  return newDelay;
 }
 
 /**
  * This method calls the Promise function (`checkOpStatus()`) to check the
  * status of an operation and schedules a retry if the operation is still not
- * completed. The retry delay is modelled as a fibonacci sequence.  
- * 
+ * completed. The retry delay is modelled as a fibonacci sequence.
+ *
  * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} opId the unique identifier of the operation we want to check
  * @param {number} delay the delay with which the next retry is to be scheduled
@@ -77,53 +77,61 @@ function getFibonacciDelay(delay) {
  * @param {number} retryCount the current number of retried attempted
  */
 function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
-    checkOpStatus(client, opId)
-        .then((status) => {
-            // success scenario
-            console.log(status);
-        })
-        .catch((status) => {
-             // fail (not yet complete) scenario
-            if (retryCount < maxtries) {
-                console.log(`${status} will try after ${delay / 1000}s delay...`);
-                const newDelay = getFibonacciDelay(delay);
-                setTimeout(
-                    () => checkStatusWithRetry(client, opId, newDelay, maxtries, retryCount + 1),
-                    delay);
-            } else {
-                console.log(`${status} max retries reached, giving up.`);
-            }
-        })
+  checkOpStatus(client, opId)
+    .then(status => {
+      // success scenario
+      console.log(status);
+    })
+    .catch(status => {
+      // fail (not yet complete) scenario
+      if (retryCount < maxtries) {
+        console.log(`${status} will try after ${delay / 1000}s delay...`);
+        const newDelay = getFibonacciDelay(delay);
+        setTimeout(
+          () =>
+            checkStatusWithRetry(
+              client,
+              opId,
+              newDelay,
+              maxtries,
+              retryCount + 1
+            ),
+          delay
+        );
+      } else {
+        console.log(`${status} max retries reached, giving up.`);
+      }
+    });
 }
 
 /**
  * This method creates a GKE cluster using the given client in the GCP project
  * and zone indicated by the `gcpProject` and `gcpZone` parameters. The last
  * argment is used as the name given to the newly created cluster.
- * 
+ *
  * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} gcpProject the GCP project where the cluster is to be created
  * @param {string} gcpZone the GCP zone where the cluster is to be created
  * @param {string} clusterName the name to be given to the new cluster
  */
 async function createCluster(client, gcpProject, gcpZone, clusterName) {
-    const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
-    const request = {
-        parent: clusterLocation,
-        cluster: {
-            name: clusterName,
-            initialNodeCount: 2,
-            nodeConfig: {
-                machineType: 'e2-standard-2'
-            },
-        },
-    };
-    // invoke the create cluster API using the client
-    const [createOperation] = await client.createCluster(request);
-    // extract the unique identifier of the operation to checkback status
-    const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
-    // schedule polling to check if the creation operation is completed
-    checkStatusWithRetry(client, opIdentifier, 1000, 20);
+  const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
+  const request = {
+    parent: clusterLocation,
+    cluster: {
+      name: clusterName,
+      initialNodeCount: 2,
+      nodeConfig: {
+        machineType: 'e2-standard-2',
+      },
+    },
+  };
+  // invoke the create cluster API using the client
+  const [createOperation] = await client.createCluster(request);
+  // extract the unique identifier of the operation to checkback status
+  const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
+  // schedule polling to check if the creation operation is completed
+  checkStatusWithRetry(client, opIdentifier, 1000, 20);
 }
 
 /**
@@ -131,26 +139,26 @@ async function createCluster(client, gcpProject, gcpZone, clusterName) {
  * 1. The GCP Project to use
  * 2. The GCP Zone to use
  * 3. The name to give to the new GKE cluster
- * 
+ *
  * > node create_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
  */
 async function main() {
-    if (!!!args.project) {
-        console.log('Missing project argument. (e.g. --project=test_project)');
-        exit(1);
-    }
-    if (!!!args.zone) {
-        console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
-        exit(1);
-    }
-    if (!!!args.name) {
-        console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
-        exit(1);
-    }
-    // Create the Cluster Manager Client
-    const client = new container.v1.ClusterManagerClient();
-    // Create a new GKE cluster
-    createCluster(client, args.project, args.zone, args.name);
+  if (!args.project) {
+    console.log('Missing project argument. (e.g. --project=test_project)');
+    exit(1);
+  }
+  if (!args.zone) {
+    console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
+    exit(1);
+  }
+  if (!args.name) {
+    console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
+    exit(1);
+  }
+  // Create the Cluster Manager Client
+  const client = new container.v1.ClusterManagerClient();
+  // Create a new GKE cluster
+  createCluster(client, args.project, args.zone, args.name);
 }
 
 // program starts here

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -116,7 +116,7 @@ function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
  * @param {string} gcpZone the GCP zone where the cluster is to be created
  * @param {string} clusterName the name to be given to the new cluster
  */
-async function createCluster(gcpZone, clusterName) {
+async function createCluster(gcpZone, clusterName, networkName) {
   // Create the Cluster Manager Client
   const client = new container.v1.ClusterManagerClient();
   const gcpProject = await client.getProjectId();
@@ -125,6 +125,7 @@ async function createCluster(gcpZone, clusterName) {
     parent: clusterLocation,
     cluster: {
       name: clusterName,
+      network: networkName,
       initialNodeCount: 2,
       nodeConfig: {
         machineType: 'e2-standard-2',
@@ -147,16 +148,21 @@ async function createCluster(gcpZone, clusterName) {
  * > node create_cluster.js --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
  */
 async function main() {
-  if (!args.zone) {
-    console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
+  if (!args.name || !args.zone) {
+    console.log(
+      'Missing argument. Required name and zone (e.g. --name=gke-cluster, --zone=us-west1-a)'
+    );
     exit(1);
   }
-  if (!args.name) {
-    console.log('Missing cluster name argument. (e.g. --name=gke-cluster)');
-    exit(1);
+  // use the default network if no network is provided
+  let network = 'default';
+  if (args.network) {
+    network = args.network;
+  } else {
+    console.log(`No network provided; using ${network} network`);
   }
   // Create a new GKE cluster
-  createCluster(args.zone, args.name);
+  createCluster(args.zone, args.name, network);
 }
 
 // program starts here

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -19,7 +19,7 @@
 // load the google-cloud nodejs library for GKE
 const container = require('@google-cloud/container');
 const args = require('yargs').argv;
-const { exit } = require('process');
+const {exit} = require('process');
 
 // assign the operation status enum to a variable for easy access
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
@@ -62,9 +62,9 @@ const checkOpStatus = (client, opId) => {
  * @returns the next delay before retrying
  */
 function getFibonacciDelay(delay) {
-    const newDelay = prevFibonacciDelay + delay;
-    prevFibonacciDelay = delay;
-    return newDelay;
+  const newDelay = prevFibonacciDelay + delay;
+  prevFibonacciDelay = delay;
+  return newDelay;
 }
 
 /**

--- a/samples/create_cluster.js
+++ b/samples/create_cluster.js
@@ -152,7 +152,7 @@ async function main() {
     exit(1);
   }
   if (!args.name) {
-    console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
+    console.log('Missing cluster name argument. (e.g. --name=gke-cluster)');
     exit(1);
   }
   // Create a new GKE cluster

--- a/samples/delete_cluster.js
+++ b/samples/delete_cluster.js
@@ -39,16 +39,16 @@ let prevFibonacciDelay = 0;
  * @returns a Promise that wraps the status check function
  */
 const checkOpStatus = (client, opId) => {
-    const getOpFn = async (resolve, reject) => {
-        const [longRunningOp] = await client.getOperation({ name: opId });
-        const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
-        if (longRunningOp.status === DONE) {
-            resolve('Cluster deletion completed.');
-        } else {
-            reject('Cluster deletion not complete.');
-        }
-    };
-    return new Promise(getOpFn);
+  const getOpFn = async (resolve, reject) => {
+    const [longRunningOp] = await client.getOperation({name: opId});
+    const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
+    if (longRunningOp.status === DONE) {
+      resolve('Cluster deletion completed.');
+    } else {
+      reject('Cluster deletion not complete.');
+    }
+  };
+  return new Promise(getOpFn);
 };
 
 /**
@@ -78,31 +78,31 @@ function getFibonacciDelay(delay) {
  * @param {number} retryCount the current number of retried attempted
  */
 function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
-    checkOpStatus(client, opId)
-        .then(status => {
-            // success scenario
-            console.log(status);
-        })
-        .catch(status => {
-            // fail (not yet complete) scenario
-            if (retryCount < maxtries) {
-                console.log(`${status} will try after ${delay / 1000}s delay...`);
-                const newDelay = getFibonacciDelay(delay);
-                setTimeout(
-                    () =>
-                        checkStatusWithRetry(
-                            client,
-                            opId,
-                            newDelay,
-                            maxtries,
-                            retryCount + 1
-                        ),
-                    delay
-                );
-            } else {
-                console.log(`${status} max retries reached, giving up.`);
-            }
-        });
+  checkOpStatus(client, opId)
+    .then(status => {
+      // success scenario
+      console.log(status);
+    })
+    .catch(status => {
+      // fail (not yet complete) scenario
+      if (retryCount < maxtries) {
+        console.log(`${status} will try after ${delay / 1000}s delay...`);
+        const newDelay = getFibonacciDelay(delay);
+        setTimeout(
+          () =>
+            checkStatusWithRetry(
+              client,
+              opId,
+              newDelay,
+              maxtries,
+              retryCount + 1
+            ),
+          delay
+        );
+      } else {
+        console.log(`${status} max retries reached, giving up.`);
+      }
+    });
 }
 
 /**
@@ -116,16 +116,16 @@ function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
  * @param {string} clusterName the name to be given to the new cluster
  */
 async function deleteCluster(gcpZone, clusterName) {
-    const client = new container.v1.ClusterManagerClient();
-    const gcpProject = await client.getProjectId();
-    const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
-    const request = { name: `${clusterLocation}/clusters/${clusterName}` };
-    // invoke the delete cluster API using the client
-    const [deleteOperation] = await client.deleteCluster(request);
-    // extract the unique identifier of the operation to checkback status
-    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
-    // schedule polling to check if the deletion operation is completed
-    checkStatusWithRetry(client, opIdentifier, 1000, 20);
+  const client = new container.v1.ClusterManagerClient();
+  const gcpProject = await client.getProjectId();
+  const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
+  const request = {name: `${clusterLocation}/clusters/${clusterName}`};
+  // invoke the delete cluster API using the client
+  const [deleteOperation] = await client.deleteCluster(request);
+  // extract the unique identifier of the operation to checkback status
+  const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+  // schedule polling to check if the deletion operation is completed
+  checkStatusWithRetry(client, opIdentifier, 1000, 20);
 }
 
 /**
@@ -136,16 +136,16 @@ async function deleteCluster(gcpZone, clusterName) {
  * > node delete_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
  */
 async function main() {
-    if (!args.zone) {
-        console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
-        exit(1);
-    }
-    if (!args.name) {
-        console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
-        exit(1);
-    }
-    // Delete the GKE cluster
-    deleteCluster(args.zone, args.name);
+  if (!args.zone) {
+    console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
+    exit(1);
+  }
+  if (!args.name) {
+    console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
+    exit(1);
+  }
+  // Delete the GKE cluster
+  deleteCluster(args.zone, args.name);
 }
 
 // program starts here

--- a/samples/delete_cluster.js
+++ b/samples/delete_cluster.js
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START gke_delete_cluster]
 'use strict';
+
+// [START gke_delete_cluster]
 
 // load the google-cloud nodejs library for GKE
 const container = require('@google-cloud/container');
 const args = require('yargs').argv;
-const {exit} = require('process');
+const { exit } = require('process');
 
 // assign the operation status enum to a variable for easy access
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
@@ -61,9 +62,9 @@ const checkOpStatus = (client, opId) => {
  * @returns the next delay before retrying
  */
 function getFibonacciDelay(delay) {
-  const newDelay = prevFibonacciDelay + delay;
-  prevFibonacciDelay = delay;
-  return newDelay;
+    const newDelay = prevFibonacciDelay + delay;
+    prevFibonacciDelay = delay;
+    return newDelay;
 }
 
 /**

--- a/samples/delete_cluster.js
+++ b/samples/delete_cluster.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START gke_delete_cluster]
 'use strict';
 
 // load the google-cloud nodejs library for GKE
@@ -21,7 +22,7 @@ const { exit } = require('process');
 
 // assign the operation status enum to a variable for easy access
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
-var prevFibonacciDelay = 0;
+let prevFibonacciDelay = 0;
 
 /**
  * This function define a function that calls the `getOperation` API to fetch
@@ -29,10 +30,10 @@ var prevFibonacciDelay = 0;
  * the defined function wrapped in a Promise. The function it defines takes in a
  * google cloud client along with the unique identifier of the operation we want
  * to check.
- * 
+ *
  * The response to the defined function is a 'Promise.reject' if the operation
- * is still not complete and a 'Promise.resolve' if it is complete. 
- * 
+ * is still not complete and a 'Promise.resolve' if it is complete.
+ *
  * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} opId the unique identifier of the operation we want to check
  * @returns a Promise that wraps the status check function
@@ -46,16 +47,16 @@ const checkOpStatus = (client, opId) => {
         } else {
             reject('Cluster deletion not complete.');
         }
-    }
+    };
     return new Promise(getOpFn);
-}
+};
 
 /**
  * A simple function that returns the next number in a fibonacci sequence that
  * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
  * as f(n - 2). This function is used to simulate a fibonacci sequence for the
  * backing off (delay) time used when retrying.
- * 
+ *
  * @param {number} delay the previous delay in the sequence
  * @returns the next delay before retrying
  */
@@ -68,8 +69,8 @@ function getFibonacciDelay(delay) {
 /**
  * This method calls the Promise function (`checkOpStatus()`) to check the
  * status of an operation and schedules a retry if the operation is still not
- * completed. The retry delay is modelled as a fibonacci sequence.  
- * 
+ * completed. The retry delay is modelled as a fibonacci sequence.
+ *
  * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} opId the unique identifier of the operation we want to check
  * @param {number} delay the delay with which the next retry is to be scheduled
@@ -78,35 +79,45 @@ function getFibonacciDelay(delay) {
  */
 function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
     checkOpStatus(client, opId)
-        .then((status) => {
+        .then(status => {
             // success scenario
             console.log(status);
         })
-        .catch((status) => {
+        .catch(status => {
             // fail (not yet complete) scenario
             if (retryCount < maxtries) {
                 console.log(`${status} will try after ${delay / 1000}s delay...`);
                 const newDelay = getFibonacciDelay(delay);
                 setTimeout(
-                    () => checkStatusWithRetry(client, opId, newDelay, maxtries, retryCount + 1),
-                    delay);
+                    () =>
+                        checkStatusWithRetry(
+                            client,
+                            opId,
+                            newDelay,
+                            maxtries,
+                            retryCount + 1
+                        ),
+                    delay
+                );
             } else {
                 console.log(`${status} max retries reached, giving up.`);
             }
-        })
+        });
 }
 
 /**
  * This method deletes a GKE cluster in the GCP project and zone indicated by
  * the `gcpProject` and `gcpZone` parameters using the given client. The last
  * argment is the name of the cluster to be deleted.
- * 
+ *
  * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} gcpProject the GCP project where the cluster is in
  * @param {string} gcpZone the GCP zone where the cluster is in
  * @param {string} clusterName the name to be given to the new cluster
  */
-async function deleteCluster(client, gcpProject, gcpZone, clusterName) {
+async function deleteCluster(gcpZone, clusterName) {
+    const client = new container.v1.ClusterManagerClient();
+    const gcpProject = await client.getProjectId();
     const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
     const request = { name: `${clusterLocation}/clusters/${clusterName}` };
     // invoke the delete cluster API using the client
@@ -119,30 +130,24 @@ async function deleteCluster(client, gcpProject, gcpZone, clusterName) {
 
 /**
  * Entrypoint into the sample. Expects three arguments to the program.
- * 1. The GCP Project to use
- * 2. The GCP Zone to use
- * 3. The name to give to the new GKE cluster
- * 
+ * 1. The GCP Zone to use
+ * 2. The name to give to the new GKE cluster
+ *
  * > node delete_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
  */
 async function main() {
-    if (!!!args.project) {
-        console.log('Missing project argument. (e.g. --project=test_project)');
-        exit(1);
-    }
-    if (!!!args.zone) {
+    if (!args.zone) {
         console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
         exit(1);
     }
-    if (!!!args.name) {
+    if (!args.name) {
         console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
         exit(1);
     }
-    // Create the Cluster Manager Client
-    const client = new container.v1.ClusterManagerClient();
     // Delete the GKE cluster
-    deleteCluster(client, args.project, args.zone, args.name);
+    deleteCluster(args.zone, args.name);
 }
 
 // program starts here
 main().catch(console.error);
+// [END gke_delete_cluster]

--- a/samples/delete_cluster.js
+++ b/samples/delete_cluster.js
@@ -19,7 +19,7 @@
 // load the google-cloud nodejs library for GKE
 const container = require('@google-cloud/container');
 const args = require('yargs').argv;
-const { exit } = require('process');
+const {exit} = require('process');
 
 // assign the operation status enum to a variable for easy access
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
@@ -62,9 +62,9 @@ const checkOpStatus = (client, opId) => {
  * @returns the next delay before retrying
  */
 function getFibonacciDelay(delay) {
-    const newDelay = prevFibonacciDelay + delay;
-    prevFibonacciDelay = delay;
-    return newDelay;
+  const newDelay = prevFibonacciDelay + delay;
+  prevFibonacciDelay = delay;
+  return newDelay;
 }
 
 /**

--- a/samples/delete_cluster.js
+++ b/samples/delete_cluster.js
@@ -137,12 +137,10 @@ async function deleteCluster(gcpZone, clusterName) {
  * > node delete_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
  */
 async function main() {
-  if (!args.zone) {
-    console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
-    exit(1);
-  }
-  if (!args.name) {
-    console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
+  if (!args.name || !args.zone) {
+    console.log(
+      'Missing argument. Required name and zone (e.g. --name=gke-cluster, --zone=us-west1-a)'
+    );
     exit(1);
   }
   // Delete the GKE cluster

--- a/samples/delete_cluster.js
+++ b/samples/delete_cluster.js
@@ -14,139 +14,142 @@
 
 'use strict';
 
-// [START gke_delete_cluster]
-
-// load the google-cloud nodejs library for GKE
-const container = require('@google-cloud/container');
-const args = require('yargs').argv;
-const {exit} = require('process');
-
-// assign the operation status enum to a variable for easy access
-const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
-let prevFibonacciDelay = 0;
-
 /**
- * This function define a function that calls the `getOperation` API to fetch
- * the details of a specific operation and checks for its completion. It returns
- * the defined function wrapped in a Promise. The function it defines takes in a
- * google cloud client along with the unique identifier of the operation we want
- * to check.
+ * Entrypoint into the sample. Expects two arguments to the program.
+ * 1. The name of the GKE cluster to be deleted
+ * 2. The GCP Zone of the cluster to be deleted
  *
- * The response to the defined function is a 'Promise.reject' if the operation
- * is still not complete and a 'Promise.resolve' if it is complete.
- *
- * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
- * @param {string} opId the unique identifier of the operation we want to check
- * @returns a Promise that wraps the status check function
+ * > node delete_cluster.js <CLUSTER_NAME> <GCP_ZONE>
  */
-const checkOpStatus = (client, opId) => {
-  const getOpFn = async (resolve, reject) => {
-    const [longRunningOp] = await client.getOperation({name: opId});
-    const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
-    if (longRunningOp.status === DONE) {
-      resolve('Cluster deletion completed.');
-    } else {
-      reject('Cluster deletion not complete.');
-    }
-  };
-  return new Promise(getOpFn);
-};
+async function main(
+  clusterName = 'Name to be given to the GKE cluster',
+  clusterZone = 'Location where the cluster is to be created'
+) {
+  // [START gke_delete_cluster]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const clusterName = 'sample-gke-cluster';
+  // const clusterZone = 'us-central1-c';
 
-/**
- * A simple function that returns the next number in a fibonacci sequence that
- * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
- * as f(n - 2). This function is used to simulate a fibonacci sequence for the
- * backing off (delay) time used when retrying.
- *
- * @param {number} delay the previous delay in the sequence
- * @returns the next delay before retrying
- */
-function getFibonacciDelay(delay) {
-  const newDelay = prevFibonacciDelay + delay;
-  prevFibonacciDelay = delay;
-  return newDelay;
-}
+  // load the google-cloud nodejs library for GKE
+  const container = require('@google-cloud/container');
+  // assign the operation status enum to a variable for easy access
+  const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+  // define fib(0) for the fibonacci series we use for delay calculation
+  let prevFibonacciDelay = 0;
 
-/**
- * This method calls the Promise function (`checkOpStatus()`) to check the
- * status of an operation and schedules a retry if the operation is still not
- * completed. The retry delay is modelled as a fibonacci sequence.
- *
- * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
- * @param {string} opId the unique identifier of the operation we want to check
- * @param {number} delay the delay with which the next retry is to be scheduled
- * @param {number} maxtries maximum number of retry attempts to go before giving up
- * @param {number} retryCount the current number of retried attempted
- */
-function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
-  checkOpStatus(client, opId)
-    .then(status => {
-      // success scenario
-      console.log(status);
-    })
-    .catch(status => {
-      // fail (not yet complete) scenario
-      if (retryCount < maxtries) {
-        console.log(`${status} will try after ${delay / 1000}s delay...`);
-        const newDelay = getFibonacciDelay(delay);
-        setTimeout(
-          () =>
-            checkStatusWithRetry(
-              client,
-              opId,
-              newDelay,
-              maxtries,
-              retryCount + 1
-            ),
-          delay
-        );
+  /**
+   * This function calls the `getOperation` API to fetch the details of a specific
+   * operation and checks for its completion. It returns the defined function
+   * wrapped in a Promise. The function it defines takes in a google cloud client
+   * along with the unique identifier of the operation we want to check.
+   *
+   * The response to the defined function is a 'Promise.reject' if the operation
+   * is still not complete and a 'Promise.resolve' if it is complete.
+   *
+   * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
+   * @param {string} opId the unique identifier of the operation we want to check
+   * @returns a Promise that wraps the status check function
+   */
+  const checkOpStatus = (client, opId) => {
+    const getOpFn = async (resolve, reject) => {
+      const [longRunningOp] = await client.getOperation({name: opId});
+      const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
+      if (longRunningOp.status === DONE) {
+        resolve('Cluster deletion completed.');
       } else {
-        console.log(`${status} max retries reached, giving up.`);
+        reject('Cluster deletion not complete.');
       }
-    });
-}
+    };
+    return new Promise(getOpFn);
+  };
 
-/**
- * This method deletes a GKE cluster in the GCP project and zone indicated by
- * the `gcpProject` and `gcpZone` parameters using the given client. The last
- * argment is the name of the cluster to be deleted.
- *
- * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
- * @param {string} gcpProject the GCP project where the cluster is in
- * @param {string} gcpZone the GCP zone where the cluster is in
- * @param {string} clusterName the name to be given to the new cluster
- */
-async function deleteCluster(gcpZone, clusterName) {
-  const client = new container.v1.ClusterManagerClient();
-  const gcpProject = await client.getProjectId();
-  const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
-  const request = {name: `${clusterLocation}/clusters/${clusterName}`};
-  // invoke the delete cluster API using the client
-  const [deleteOperation] = await client.deleteCluster(request);
-  // extract the unique identifier of the operation to checkback status
-  const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
-  // schedule polling to check if the deletion operation is completed
-  checkStatusWithRetry(client, opIdentifier, 1000, 20);
-}
-
-/**
- * Entrypoint into the sample. Expects three arguments to the program.
- * 1. The GCP Zone to use
- * 2. The name to give to the new GKE cluster
- *
- * > node delete_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
- */
-async function main() {
-  if (!args.name || !args.zone) {
-    console.log(
-      'Missing argument. Required name and zone (e.g. --name=gke-cluster, --zone=us-west1-a)'
-    );
-    exit(1);
+  /**
+   * This method calls the Promise function (`checkOpStatus()`) to check the
+   * status of an operation and schedules a retry if the operation is still not
+   * completed. The retry delay is modelled as a fibonacci sequence.
+   *
+   * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+   * @param {string} opId the unique identifier of the operation we want to check
+   * @param {number} delay the delay with which the next retry is to be scheduled
+   * @param {number} maxtries maximum number of retry attempts to go before giving up
+   * @param {number} retryCount the current number of retried attempted
+   */
+  function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
+    checkOpStatus(client, opId)
+      .then(status => {
+        // success scenario
+        console.log(status);
+      })
+      .catch(status => {
+        // fail (not yet complete) scenario
+        if (retryCount < maxtries) {
+          console.log(`${status} will try after ${delay / 1000}s delay...`);
+          const newDelay = getFibonacciDelay(delay);
+          setTimeout(
+            () =>
+              checkStatusWithRetry(
+                client,
+                opId,
+                newDelay,
+                maxtries,
+                retryCount + 1
+              ),
+            delay
+          );
+        } else {
+          console.log(`${status} max retries reached, giving up.`);
+        }
+      });
   }
+
+  /**
+   * A simple function that returns the next number in a fibonacci sequence that
+   * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
+   * as f(n - 2). This function is used to simulate a fibonacci sequence for the
+   * backing off (delay) time used when retrying.
+   *
+   * @param {number} delay the previous delay in the sequence
+   * @returns the next delay before retrying
+   */
+  function getFibonacciDelay(delay) {
+    const newDelay = prevFibonacciDelay + delay;
+    prevFibonacciDelay = delay;
+    return newDelay;
+  }
+
+  /**
+   * This method deletes the GKE cluster pointed to by `clusterName` which is
+   * in the zone indicated by `clusterZone`.
+   */
+  async function deleteCluster() {
+    // Create the Cluster Manager Client
+    const client = new container.v1.ClusterManagerClient();
+    const gcpProject = await client.getProjectId();
+    const clusterLocation = `projects/${gcpProject}/locations/${clusterZone}`;
+    const request = {name: `${clusterLocation}/clusters/${clusterName}`};
+    // invoke the delete cluster API using the client
+    const [deleteOperation] = await client.deleteCluster(request);
+    // extract the unique identifier of the operation to checkback status
+    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+    // initial delay before retry in milli seconds
+    const retryDelay = 1000;
+    // maximum number of times to check for operation completion before giving up
+    const maxRetryCount = 20;
+    // schedule polling to check if the deletion operation is completed
+    checkStatusWithRetry(client, opIdentifier, retryDelay, maxRetryCount);
+  }
+
   // Delete the GKE cluster
-  deleteCluster(args.zone, args.name);
+  deleteCluster();
+  // [END gke_delete_cluster]
 }
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
 
 // program starts here
-main().catch(console.error);
-// [END gke_delete_cluster]
+main(...process.argv.slice(2));

--- a/samples/delete_cluster.js
+++ b/samples/delete_cluster.js
@@ -1,0 +1,148 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+// load the google-cloud nodejs library for GKE
+const container = require('@google-cloud/container');
+const args = require('yargs').argv;
+const { exit } = require('process');
+
+// assign the operation status enum to a variable for easy access
+const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+var prevFibonacciDelay = 0;
+
+/**
+ * This function define a function that calls the `getOperation` API to fetch
+ * the details of a specific operation and checks for its completion. It returns
+ * the defined function wrapped in a Promise. The function it defines takes in a
+ * google cloud client along with the unique identifier of the operation we want
+ * to check.
+ * 
+ * The response to the defined function is a 'Promise.reject' if the operation
+ * is still not complete and a 'Promise.resolve' if it is complete. 
+ * 
+ * @param {container.vq.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} opId the unique identifier of the operation we want to check
+ * @returns a Promise that wraps the status check function
+ */
+const checkOpStatus = (client, opId) => {
+    const getOpFn = async (resolve, reject) => {
+        const [longRunningOp] = await client.getOperation({ name: opId });
+        const DONE = STATUS_ENUM[STATUS_ENUM.DONE];
+        if (longRunningOp.status === DONE) {
+            resolve('Cluster deletion completed.');
+        } else {
+            reject('Cluster deletion not complete.');
+        }
+    }
+    return new Promise(getOpFn);
+}
+
+/**
+ * A simple function that returns the next number in a fibonacci sequence that
+ * has the given argument as f(n-1) and the global variable `prevFibonacciDelay`
+ * as f(n - 2). This function is used to simulate a fibonacci sequence for the
+ * backing off (delay) time used when retrying.
+ * 
+ * @param {number} delay the previous delay in the sequence
+ * @returns the next delay before retrying
+ */
+function getFibonacciDelay(delay) {
+    const newDelay = prevFibonacciDelay + delay;
+    prevFibonacciDelay = delay;
+    return newDelay;
+}
+
+/**
+ * This method calls the Promise function (`checkOpStatus()`) to check the
+ * status of an operation and schedules a retry if the operation is still not
+ * completed. The retry delay is modelled as a fibonacci sequence.  
+ * 
+ * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} opId the unique identifier of the operation we want to check
+ * @param {number} delay the delay with which the next retry is to be scheduled
+ * @param {number} maxtries maximum number of retry attempts to go before giving up
+ * @param {number} retryCount the current number of retried attempted
+ */
+function checkStatusWithRetry(client, opId, delay, maxtries, retryCount = 1) {
+    checkOpStatus(client, opId)
+        .then((status) => {
+            // success scenario
+            console.log(status);
+        })
+        .catch((status) => {
+            // fail (not yet complete) scenario
+            if (retryCount < maxtries) {
+                console.log(`${status} will try after ${delay / 1000}s delay...`);
+                const newDelay = getFibonacciDelay(delay);
+                setTimeout(
+                    () => checkStatusWithRetry(client, opId, newDelay, maxtries, retryCount + 1),
+                    delay);
+            } else {
+                console.log(`${status} max retries reached, giving up.`);
+            }
+        })
+}
+
+/**
+ * This method deletes a GKE cluster in the GCP project and zone indicated by
+ * the `gcpProject` and `gcpZone` parameters using the given client. The last
+ * argment is the name of the cluster to be deleted.
+ * 
+ * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} gcpProject the GCP project where the cluster is in
+ * @param {string} gcpZone the GCP zone where the cluster is in
+ * @param {string} clusterName the name to be given to the new cluster
+ */
+async function deleteCluster(client, gcpProject, gcpZone, clusterName) {
+    const clusterLocation = `projects/${gcpProject}/locations/${gcpZone}`;
+    const request = { name: `${clusterLocation}/clusters/${clusterName}` };
+    // invoke the delete cluster API using the client
+    const [deleteOperation] = await client.deleteCluster(request);
+    // extract the unique identifier of the operation to checkback status
+    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+    // schedule polling to check if the deletion operation is completed
+    checkStatusWithRetry(client, opIdentifier, 1000, 20);
+}
+
+/**
+ * Entrypoint into the sample. Expects three arguments to the program.
+ * 1. The GCP Project to use
+ * 2. The GCP Zone to use
+ * 3. The name to give to the new GKE cluster
+ * 
+ * > node delete_cluster.js --project=<GCP_PROJECT> --zone=<GCP_ZONE> --name=<CLUSTER_NAME>
+ */
+async function main() {
+    if (!!!args.project) {
+        console.log('Missing project argument. (e.g. --project=test_project)');
+        exit(1);
+    }
+    if (!!!args.zone) {
+        console.log('Missing zone argument. (e.g. --zone=us-west1-a)');
+        exit(1);
+    }
+    if (!!!args.name) {
+        console.log('Missing cluster name argument. (e.g. --name=gke_cluster)');
+        exit(1);
+    }
+    // Create the Cluster Manager Client
+    const client = new container.v1.ClusterManagerClient();
+    // Delete the GKE cluster
+    deleteCluster(client, args.project, args.zone, args.name);
+}
+
+// program starts here
+main().catch(console.error);

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,8 @@
     "test": "mocha system-test --timeout 10000"
   },
   "dependencies": {
-    "@google-cloud/container": "^2.6.0"
+    "@google-cloud/container": "^2.6.0",
+    "yargs": "^17.3.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@google-cloud/container": "^2.6.0",
+    "uuid": "^8.3.2",
     "yargs": "^17.3.1"
   },
   "devDependencies": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -15,8 +15,7 @@
   },
   "dependencies": {
     "@google-cloud/container": "^2.6.0",
-    "uuid": "^8.3.2",
-    "yargs": "^17.3.1"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -11,7 +11,7 @@
     "*.js"
   ],
   "scripts": {
-    "test": "mocha system-test --timeout 10000"
+    "test": "mocha system-test --timeout 1000000"
   },
   "dependencies": {
     "@google-cloud/container": "^2.6.0",

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -31,8 +31,7 @@ async function main() {
     };
 
     const [response] = await client.listClusters(request);
-    console.log('Clusters:');
-    console.log(response);
+    console.log('Clusters: ', response);
   }
   quickstart();
   // [END container_quickstart]

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START gke_list_cluster]
 'use strict';
 
+// [START gke_list_cluster]
 async function main() {
   // [START container_quickstart]
   const container = require('@google-cloud/container');

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START gke_list_cluster]
 'use strict';
 
 async function main() {
@@ -38,3 +39,4 @@ async function main() {
 }
 
 main().catch(console.error);
+// [END gke_list_cluster]

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -1,0 +1,71 @@
+// Copyright 2017 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { assert, expect } = require('chai');
+const { describe, it } = require('mocha');
+const { randomUUID } = require('crypto');
+const container = require('@google-cloud/container');
+const cp = require('child_process');
+const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+
+const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+
+describe('container samples - create cluster long running op', async () => {
+    const zones = ['us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f']
+    const randomZone = zones[Math.floor(Math.random() * zones.length)];
+    const randomClusterName = `nodejs-container-test-${randomUUID().substring(0, 8)}`
+    const client = new container.v1.ClusterManagerClient();
+    const projectId = await client.getProjectId();
+    const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
+
+    // clean up the cluster regardless of whether the test passed or not
+    afterEach(async () => {
+        const request = { name: `${clusterLocation}/clusters/${randomClusterName}` };
+        const [deleteOperation] = await client.deleteCluster(request);
+        const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+
+        const maxRetries = 20;
+        var retryCount = 0;
+        var prevDelay = 0;
+        var currDelay = 1000;
+
+        async function timeOutFn() {
+            if (retryCount >= maxRetries) {
+                return;
+            }
+            const [longRunningOp] = await client.getOperation({ name: opIdentifier });
+            const status = longRunningOp.status;
+            if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+                const newDelay = prevDelay + currDelay;
+                prevDelay = currDelay;
+                currDelay = newDelay;
+                setTimeout(timeOutFn, currDelay);
+            }
+            retryCount += 1;
+        }
+        timeOutFn();
+    });
+
+    it('should create cluster and wait for completion', async () => {
+        const stdout = execSync(`node create_cluster.js --zone=${randomZone} --name=${randomClusterName}`);
+        assert.match(stdout, /Cluster creation not complete. will try after .* delay/);
+        assert.match(stdout, /Cluster creation completed./);
+
+        const [response] = await client.listClusters({ projectId: projectId, zone: randomZone });
+        const clustersList = response.clusters.reduce((acc, curr) => [curr.name, ...acc], []);
+        expect(clustersList).to.include(randomClusterName);
+    }).timeout(1000000);
+});

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -16,7 +16,7 @@
 
 const {assert, expect} = require('chai');
 const {describe, it, before, after} = require('mocha');
-const randomUUID = require('uuid');
+const uuid = require('uuid');
 const cp = require('child_process');
 const container = require('@google-cloud/container');
 const untilDone = require('./test_util.js');
@@ -29,10 +29,8 @@ const zones = [
   'us-central1-f',
 ];
 const randomZone = zones[Math.floor(Math.random() * zones.length)];
-const randomClusterName = `nodejs-container-test-${randomUUID.v1().substring(
-  0,
-  8
-)}`;
+const randomUUID = uuid.v1().substring(0, 8);
+const randomClusterName = `nodejs-container-test-${randomUUID}`;
 const client = new container.v1.ClusterManagerClient();
 let projectId;
 let clusterLocation;

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -14,14 +14,14 @@
 
 'use strict';
 
-const { assert, expect } = require('chai');
-const { describe, it, before, after } = require('mocha');
+const {assert, expect} = require('chai');
+const {describe, it, before, after} = require('mocha');
 const uuid = require('uuid');
 const cp = require('child_process');
 const container = require('@google-cloud/container');
 const untilDone = require('./test_util.js');
 
-const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const zones = [
   'us-central1-a',
   'us-central1-b',
@@ -69,7 +69,7 @@ describe('container samples - create cluster long running op', () => {
 
 // clean up the cluster regardless of whether the test passed or not
 after(async () => {
-  const request = { name: `${clusterLocation}/clusters/${randomClusterName}` };
+  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
   const [deleteOperation] = await client.deleteCluster(request);
   const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
   await untilDone(client, opIdentifier);

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -16,7 +16,7 @@
 
 const {assert, expect} = require('chai');
 const {describe, it, before, after} = require('mocha');
-const {randomUUID} = require('crypto');
+const randomUUID = require('uuid');
 const cp = require('child_process');
 const container = require('@google-cloud/container');
 const untilDone = require('./test_util.js');
@@ -29,7 +29,7 @@ const zones = [
   'us-central1-f',
 ];
 const randomZone = zones[Math.floor(Math.random() * zones.length)];
-const randomClusterName = `nodejs-container-test-${randomUUID().substring(
+const randomClusterName = `nodejs-container-test-${randomUUID.v1().substring(
   0,
   8
 )}`;

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -45,7 +45,7 @@ before(async () => {
 describe('container samples - create cluster long running op', () => {
   it('should create cluster and wait for completion', async () => {
     const stdout = execSync(
-      `node create_cluster.js --zone=${randomZone} --name=${randomClusterName} --network=${ciNetwork}`
+      `node create_cluster.js ${randomClusterName} ${randomZone} ${ciNetwork}`
     );
     assert.match(
       stdout,

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -14,58 +14,77 @@
 
 'use strict';
 
-const { assert, expect } = require('chai');
-const { describe, it } = require('mocha');
-const { randomUUID } = require('crypto');
+const {assert, expect} = require('chai');
+const {describe, it} = require('mocha');
+const {randomUUID} = require('crypto');
 const container = require('@google-cloud/container');
 const cp = require('child_process');
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
 
-const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 describe('container samples - create cluster long running op', async () => {
-    const zones = ['us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f']
-    const randomZone = zones[Math.floor(Math.random() * zones.length)];
-    const randomClusterName = `nodejs-container-test-${randomUUID().substring(0, 8)}`
-    const client = new container.v1.ClusterManagerClient();
-    const projectId = await client.getProjectId();
-    const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
+  const zones = [
+    'us-central1-a',
+    'us-central1-b',
+    'us-central1-c',
+    'us-central1-f',
+  ];
+  const randomZone = zones[Math.floor(Math.random() * zones.length)];
+  const randomClusterName = `nodejs-container-test-${randomUUID().substring(
+    0,
+    8
+  )}`;
+  const client = new container.v1.ClusterManagerClient();
+  const projectId = await client.getProjectId();
+  const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
 
-    // clean up the cluster regardless of whether the test passed or not
-    afterEach(async () => {
-        const request = { name: `${clusterLocation}/clusters/${randomClusterName}` };
-        const [deleteOperation] = await client.deleteCluster(request);
-        const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+  // clean up the cluster regardless of whether the test passed or not
+  afterEach(async () => {
+    const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
+    const [deleteOperation] = await client.deleteCluster(request);
+    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
 
-        const maxRetries = 20;
-        var retryCount = 0;
-        var prevDelay = 0;
-        var currDelay = 1000;
+    const maxRetries = 20;
+    let retryCount = 0;
+    let prevDelay = 0;
+    let currDelay = 1000;
 
-        async function timeOutFn() {
-            if (retryCount >= maxRetries) {
-                return;
-            }
-            const [longRunningOp] = await client.getOperation({ name: opIdentifier });
-            const status = longRunningOp.status;
-            if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
-                const newDelay = prevDelay + currDelay;
-                prevDelay = currDelay;
-                currDelay = newDelay;
-                setTimeout(timeOutFn, currDelay);
-            }
-            retryCount += 1;
-        }
-        timeOutFn();
+    async function timeOutFn() {
+      if (retryCount >= maxRetries) {
+        return;
+      }
+      const [longRunningOp] = await client.getOperation({name: opIdentifier});
+      const status = longRunningOp.status;
+      if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+        const newDelay = prevDelay + currDelay;
+        prevDelay = currDelay;
+        currDelay = newDelay;
+        setTimeout(timeOutFn, currDelay);
+      }
+      retryCount += 1;
+    }
+    timeOutFn();
+  });
+
+  it('should create cluster and wait for completion', async () => {
+    const stdout = execSync(
+      `node create_cluster.js --zone=${randomZone} --name=${randomClusterName}`
+    );
+    assert.match(
+      stdout,
+      /Cluster creation not complete. will try after .* delay/
+    );
+    assert.match(stdout, /Cluster creation completed./);
+
+    const [response] = await client.listClusters({
+      projectId: projectId,
+      zone: randomZone,
     });
-
-    it('should create cluster and wait for completion', async () => {
-        const stdout = execSync(`node create_cluster.js --zone=${randomZone} --name=${randomClusterName}`);
-        assert.match(stdout, /Cluster creation not complete. will try after .* delay/);
-        assert.match(stdout, /Cluster creation completed./);
-
-        const [response] = await client.listClusters({ projectId: projectId, zone: randomZone });
-        const clustersList = response.clusters.reduce((acc, curr) => [curr.name, ...acc], []);
-        expect(clustersList).to.include(randomClusterName);
-    }).timeout(1000000);
+    const clustersList = response.clusters.reduce(
+      (acc, curr) => [curr.name, ...acc],
+      []
+    );
+    expect(clustersList).to.include(randomClusterName);
+  }).timeout(1000000);
 });

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -42,6 +42,14 @@ before(async () => {
   clusterLocation = `projects/${projectId}/locations/${randomZone}`;
 });
 
+// clean up the cluster regardless of whether the test passed or not
+after(async () => {
+  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
+  const [deleteOperation] = await client.deleteCluster(request);
+  const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+  await untilDone(client, opIdentifier);
+});
+
 describe('container samples - create cluster long running op', () => {
   it('should create cluster and wait for completion', async () => {
     const stdout = execSync(
@@ -65,12 +73,4 @@ describe('container samples - create cluster long running op', () => {
     );
     expect(clustersList).to.include(randomClusterName);
   });
-});
-
-// clean up the cluster regardless of whether the test passed or not
-after(async () => {
-  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
-  const [deleteOperation] = await client.deleteCluster(request);
-  const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
-  await untilDone(client, opIdentifier);
 });

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -19,7 +19,7 @@ const {describe, it, after} = require('mocha');
 const {randomUUID} = require('crypto');
 const cp = require('child_process');
 const container = require('@google-cloud/container');
-const waitTillComplete = require('./test_util.js');
+const untilDone = require('./test_util.js');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
@@ -45,7 +45,7 @@ describe('container samples - create cluster long running op', async () => {
     const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
     const [deleteOperation] = await client.deleteCluster(request);
     const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
-    await waitTillComplete(client, opIdentifier);
+    await untilDone(client, opIdentifier);
   });
 
   it('should create cluster and wait for completion', async function () {

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -29,10 +29,9 @@ const zones = [
   'us-central1-f',
 ];
 const randomZone = zones[Math.floor(Math.random() * zones.length)];
-const randomClusterName = `nodejs-container-test-${randomUUID.v1().substring(
-  0,
-  8
-)}`;
+const randomClusterName = `nodejs-container-test-${randomUUID
+  .v1()
+  .substring(0, 8)}`;
 const client = new container.v1.ClusterManagerClient();
 let projectId;
 let clusterLocation;

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -14,14 +14,14 @@
 
 'use strict';
 
-const {assert, expect} = require('chai');
-const {describe, it, before, after} = require('mocha');
+const { assert, expect } = require('chai');
+const { describe, it, before, after } = require('mocha');
 const uuid = require('uuid');
 const cp = require('child_process');
 const container = require('@google-cloud/container');
 const untilDone = require('./test_util.js');
 
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
 const zones = [
   'us-central1-a',
   'us-central1-b',
@@ -32,6 +32,7 @@ const randomZone = zones[Math.floor(Math.random() * zones.length)];
 const randomUUID = uuid.v1().substring(0, 8);
 const randomClusterName = `nodejs-container-test-${randomUUID}`;
 const client = new container.v1.ClusterManagerClient();
+const ciNetwork = 'default-compute';
 let projectId;
 let clusterLocation;
 
@@ -44,7 +45,7 @@ before(async () => {
 describe('container samples - create cluster long running op', () => {
   it('should create cluster and wait for completion', async () => {
     const stdout = execSync(
-      `node create_cluster.js --zone=${randomZone} --name=${randomClusterName}`
+      `node create_cluster.js --zone=${randomZone} --name=${randomClusterName} --network=${ciNetwork}`
     );
     assert.match(
       stdout,
@@ -68,7 +69,7 @@ describe('container samples - create cluster long running op', () => {
 
 // clean up the cluster regardless of whether the test passed or not
 after(async () => {
-  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
+  const request = { name: `${clusterLocation}/clusters/${randomClusterName}` };
   const [deleteOperation] = await client.deleteCluster(request);
   const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
   await untilDone(client, opIdentifier);

--- a/samples/system-test/create_cluster.test.js
+++ b/samples/system-test/create_cluster.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const {assert, expect} = require('chai');
-const {describe, it} = require('mocha');
+const {describe, it, after} = require('mocha');
 const {randomUUID} = require('crypto');
 const container = require('@google-cloud/container');
 const cp = require('child_process');
@@ -40,7 +40,7 @@ describe('container samples - create cluster long running op', async () => {
   const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
 
   // clean up the cluster regardless of whether the test passed or not
-  afterEach(async () => {
+  after(async () => {
     const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
     const [deleteOperation] = await client.deleteCluster(request);
     const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -76,8 +76,8 @@ describe('container samples - delete cluster long running op', async () => {
 
   // clean up the cluster regardless of whether the test passed or not
   after(async () => {
-    const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
     let opIdentifier;
+    const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
     try {
       const [deleteOperation] = await client.deleteCluster(request);
       opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,9 +77,16 @@ describe('container samples - delete cluster long running op', async () => {
   // clean up the cluster regardless of whether the test passed or not
   after(async () => {
     const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
-    const [deleteOperation] = await client.deleteCluster(request);
-    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
-
+    let opIdentifier;
+    try {
+      const [deleteOperation] = await client.deleteCluster(request);
+      opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+    } catch (ex) {
+      // Error code 5 is NOT_FOUND meaning the cluster was deleted
+      if (ex.code === 5) {
+        return;
+      }
+    }
     const maxRetries = 20;
     let retryCount = 0;
     let prevDelay = 0;

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -16,7 +16,7 @@
 
 const {assert, expect} = require('chai');
 const {describe, it, after, before} = require('mocha');
-const {randomUUID} = require('crypto');
+const randomUUID = require('uuid');
 const cp = require('child_process');
 const container = require('@google-cloud/container');
 const untilDone = require('./test_util.js');
@@ -29,7 +29,7 @@ const zones = [
   'us-central1-f',
 ];
 const randomZone = zones[Math.floor(Math.random() * zones.length)];
-const randomClusterName = `nodejs-container-test-${randomUUID().substring(
+const randomClusterName = `nodejs-container-test-${randomUUID.v1().substring(
   0,
   8
 )}`;

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const {assert, expect} = require('chai');
-const {describe, it} = require('mocha');
+const {describe, it, after, before} = require('mocha');
 const {randomUUID} = require('crypto');
 const container = require('@google-cloud/container');
 const cp = require('child_process');
@@ -40,7 +40,7 @@ describe('container samples - delete cluster long running op', async () => {
   const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
 
   // create a new cluster to test the delete sample on
-  beforeEach(async () => {
+  before(async () => {
     const request = {
       parent: clusterLocation,
       cluster: {
@@ -75,7 +75,7 @@ describe('container samples - delete cluster long running op', async () => {
   });
 
   // clean up the cluster regardless of whether the test passed or not
-  afterEach(async () => {
+  after(async () => {
     const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
     const [deleteOperation] = await client.deleteCluster(request);
     const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -32,6 +32,7 @@ const randomZone = zones[Math.floor(Math.random() * zones.length)];
 const randomUUID = uuid.v1().substring(0, 8);
 const randomClusterName = `nodejs-container-test-${randomUUID}`;
 const client = new container.v1.ClusterManagerClient();
+const ciNetwork = 'default-compute';
 let projectId;
 let clusterLocation;
 
@@ -43,6 +44,7 @@ before(async () => {
     parent: clusterLocation,
     cluster: {
       name: randomClusterName,
+      network: ciNetwork,
       initialNodeCount: 2,
       nodeConfig: {machineType: 'e2-standard-2'},
     },

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -1,0 +1,106 @@
+// Copyright 2017 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { assert, expect } = require('chai');
+const { describe, it } = require('mocha');
+const { randomUUID } = require('crypto');
+const container = require('@google-cloud/container');
+const cp = require('child_process');
+const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+
+const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+
+describe('container samples - delete cluster long running op', async () => {
+    const zones = ['us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f']
+    const randomZone = zones[Math.floor(Math.random() * zones.length)];
+    const randomClusterName = `nodejs-container-test-${randomUUID().substring(0, 8)}`
+    const client = new container.v1.ClusterManagerClient();
+    const projectId = await client.getProjectId();
+    const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
+
+    // create a new cluster to test the delete sample on
+    beforeEach(async () => {
+        const request = {
+            parent: clusterLocation,
+            cluster: {
+                name: randomClusterName,
+                initialNodeCount: 2,
+                nodeConfig: { machineType: 'e2-standard-2' },
+            },
+        };
+        const [createOperation] = await client.createCluster(request);
+        const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
+
+        const maxRetries = 20;
+        var retryCount = 0;
+        var prevDelay = 0;
+        var currDelay = 1000;
+
+        async function timeOutFn() {
+            if (retryCount >= maxRetries) {
+                return;
+            }
+            const [longRunningOp] = await client.getOperation({ name: opIdentifier });
+            const status = longRunningOp.status;
+            if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+                const newDelay = prevDelay + currDelay;
+                prevDelay = currDelay;
+                currDelay = newDelay;
+                setTimeout(timeOutFn, currDelay);
+            }
+            retryCount += 1;
+        }
+        timeOutFn();
+    });
+
+    // clean up the cluster regardless of whether the test passed or not
+    afterEach(async () => {
+        const request = { name: `${clusterLocation}/clusters/${randomClusterName}` };
+        const [deleteOperation] = await client.deleteCluster(request);
+        const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+
+        const maxRetries = 20;
+        var retryCount = 0;
+        var prevDelay = 0;
+        var currDelay = 1000;
+
+        async function timeOutFn() {
+            if (retryCount >= maxRetries) {
+                return;
+            }
+            const [longRunningOp] = await client.getOperation({ name: opIdentifier });
+            const status = longRunningOp.status;
+            if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+                const newDelay = prevDelay + currDelay;
+                prevDelay = currDelay;
+                currDelay = newDelay;
+                setTimeout(timeOutFn, currDelay);
+            }
+            retryCount += 1;
+        }
+        timeOutFn();
+    });
+
+    it('should delete cluster and wait for completion', async () => {
+        const stdout = execSync(`node delete_cluster.js --zone=${randomZone} --name=${randomClusterName}`);
+        assert.match(stdout, /Cluster deletion not complete. will try after .* delay/);
+        assert.match(stdout, /Cluster deletion completed./);
+
+        const [response] = await client.listClusters({ projectId: projectId, zone: randomZone });
+        const clustersList = response.clusters.reduce((acc, curr) => [curr.name, ...acc], []);
+        expect(clustersList).to.not.include(randomClusterName);
+    }).timeout(1000000);
+});

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -58,7 +58,7 @@ before(async () => {
 describe('container samples - delete cluster long running op', () => {
   it('should delete cluster and wait for completion', async () => {
     const stdout = execSync(
-      `node delete_cluster.js --zone=${randomZone} --name=${randomClusterName}`
+      `node delete_cluster.js ${randomClusterName} ${randomZone}`
     );
     assert.match(
       stdout,

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -14,93 +14,112 @@
 
 'use strict';
 
-const { assert, expect } = require('chai');
-const { describe, it } = require('mocha');
-const { randomUUID } = require('crypto');
+const {assert, expect} = require('chai');
+const {describe, it} = require('mocha');
+const {randomUUID} = require('crypto');
 const container = require('@google-cloud/container');
 const cp = require('child_process');
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
 
-const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 describe('container samples - delete cluster long running op', async () => {
-    const zones = ['us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f']
-    const randomZone = zones[Math.floor(Math.random() * zones.length)];
-    const randomClusterName = `nodejs-container-test-${randomUUID().substring(0, 8)}`
-    const client = new container.v1.ClusterManagerClient();
-    const projectId = await client.getProjectId();
-    const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
+  const zones = [
+    'us-central1-a',
+    'us-central1-b',
+    'us-central1-c',
+    'us-central1-f',
+  ];
+  const randomZone = zones[Math.floor(Math.random() * zones.length)];
+  const randomClusterName = `nodejs-container-test-${randomUUID().substring(
+    0,
+    8
+  )}`;
+  const client = new container.v1.ClusterManagerClient();
+  const projectId = await client.getProjectId();
+  const clusterLocation = `projects/${projectId}/locations/${randomZone}`;
 
-    // create a new cluster to test the delete sample on
-    beforeEach(async () => {
-        const request = {
-            parent: clusterLocation,
-            cluster: {
-                name: randomClusterName,
-                initialNodeCount: 2,
-                nodeConfig: { machineType: 'e2-standard-2' },
-            },
-        };
-        const [createOperation] = await client.createCluster(request);
-        const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
+  // create a new cluster to test the delete sample on
+  beforeEach(async () => {
+    const request = {
+      parent: clusterLocation,
+      cluster: {
+        name: randomClusterName,
+        initialNodeCount: 2,
+        nodeConfig: {machineType: 'e2-standard-2'},
+      },
+    };
+    const [createOperation] = await client.createCluster(request);
+    const opIdentifier = `${clusterLocation}/operations/${createOperation.name}`;
 
-        const maxRetries = 20;
-        var retryCount = 0;
-        var prevDelay = 0;
-        var currDelay = 1000;
+    const maxRetries = 20;
+    let retryCount = 0;
+    let prevDelay = 0;
+    let currDelay = 1000;
 
-        async function timeOutFn() {
-            if (retryCount >= maxRetries) {
-                return;
-            }
-            const [longRunningOp] = await client.getOperation({ name: opIdentifier });
-            const status = longRunningOp.status;
-            if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
-                const newDelay = prevDelay + currDelay;
-                prevDelay = currDelay;
-                currDelay = newDelay;
-                setTimeout(timeOutFn, currDelay);
-            }
-            retryCount += 1;
-        }
-        timeOutFn();
+    async function timeOutFn() {
+      if (retryCount >= maxRetries) {
+        return;
+      }
+      const [longRunningOp] = await client.getOperation({name: opIdentifier});
+      const status = longRunningOp.status;
+      if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+        const newDelay = prevDelay + currDelay;
+        prevDelay = currDelay;
+        currDelay = newDelay;
+        setTimeout(timeOutFn, currDelay);
+      }
+      retryCount += 1;
+    }
+    timeOutFn();
+  });
+
+  // clean up the cluster regardless of whether the test passed or not
+  afterEach(async () => {
+    const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
+    const [deleteOperation] = await client.deleteCluster(request);
+    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+
+    const maxRetries = 20;
+    let retryCount = 0;
+    let prevDelay = 0;
+    let currDelay = 1000;
+
+    async function timeOutFn() {
+      if (retryCount >= maxRetries) {
+        return;
+      }
+      const [longRunningOp] = await client.getOperation({name: opIdentifier});
+      const status = longRunningOp.status;
+      if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+        const newDelay = prevDelay + currDelay;
+        prevDelay = currDelay;
+        currDelay = newDelay;
+        setTimeout(timeOutFn, currDelay);
+      }
+      retryCount += 1;
+    }
+    timeOutFn();
+  });
+
+  it('should delete cluster and wait for completion', async () => {
+    const stdout = execSync(
+      `node delete_cluster.js --zone=${randomZone} --name=${randomClusterName}`
+    );
+    assert.match(
+      stdout,
+      /Cluster deletion not complete. will try after .* delay/
+    );
+    assert.match(stdout, /Cluster deletion completed./);
+
+    const [response] = await client.listClusters({
+      projectId: projectId,
+      zone: randomZone,
     });
-
-    // clean up the cluster regardless of whether the test passed or not
-    afterEach(async () => {
-        const request = { name: `${clusterLocation}/clusters/${randomClusterName}` };
-        const [deleteOperation] = await client.deleteCluster(request);
-        const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
-
-        const maxRetries = 20;
-        var retryCount = 0;
-        var prevDelay = 0;
-        var currDelay = 1000;
-
-        async function timeOutFn() {
-            if (retryCount >= maxRetries) {
-                return;
-            }
-            const [longRunningOp] = await client.getOperation({ name: opIdentifier });
-            const status = longRunningOp.status;
-            if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
-                const newDelay = prevDelay + currDelay;
-                prevDelay = currDelay;
-                currDelay = newDelay;
-                setTimeout(timeOutFn, currDelay);
-            }
-            retryCount += 1;
-        }
-        timeOutFn();
-    });
-
-    it('should delete cluster and wait for completion', async () => {
-        const stdout = execSync(`node delete_cluster.js --zone=${randomZone} --name=${randomClusterName}`);
-        assert.match(stdout, /Cluster deletion not complete. will try after .* delay/);
-        assert.match(stdout, /Cluster deletion completed./);
-
-        const [response] = await client.listClusters({ projectId: projectId, zone: randomZone });
-        const clustersList = response.clusters.reduce((acc, curr) => [curr.name, ...acc], []);
-        expect(clustersList).to.not.include(randomClusterName);
-    }).timeout(1000000);
+    const clustersList = response.clusters.reduce(
+      (acc, curr) => [curr.name, ...acc],
+      []
+    );
+    expect(clustersList).to.not.include(randomClusterName);
+  }).timeout(1000000);
 });

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -29,10 +29,9 @@ const zones = [
   'us-central1-f',
 ];
 const randomZone = zones[Math.floor(Math.random() * zones.length)];
-const randomClusterName = `nodejs-container-test-${randomUUID.v1().substring(
-  0,
-  8
-)}`;
+const randomClusterName = `nodejs-container-test-${randomUUID
+  .v1()
+  .substring(0, 8)}`;
 const client = new container.v1.ClusterManagerClient();
 let projectId;
 let clusterLocation;

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -54,6 +54,21 @@ before(async () => {
   await untilDone(client, opIdentifier);
 });
 
+// clean up the cluster regardless of whether the test passed or not
+after(async () => {
+  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
+  try {
+    const [deleteOperation] = await client.deleteCluster(request);
+    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
+    await untilDone(client, opIdentifier);
+  } catch (ex) {
+    // Error code 5 is NOT_FOUND meaning the cluster was deleted during the test
+    if (ex.code === 5) {
+      return;
+    }
+  }
+});
+
 // run the tests
 describe('container samples - delete cluster long running op', () => {
   it('should delete cluster and wait for completion', async () => {
@@ -78,19 +93,4 @@ describe('container samples - delete cluster long running op', () => {
     );
     expect(clustersList).to.not.include(randomClusterName);
   });
-});
-
-// clean up the cluster regardless of whether the test passed or not
-after(async () => {
-  const request = {name: `${clusterLocation}/clusters/${randomClusterName}`};
-  try {
-    const [deleteOperation] = await client.deleteCluster(request);
-    const opIdentifier = `${clusterLocation}/operations/${deleteOperation.name}`;
-    await untilDone(client, opIdentifier);
-  } catch (ex) {
-    // Error code 5 is NOT_FOUND meaning the cluster was deleted during the test
-    if (ex.code === 5) {
-      return;
-    }
-  }
 });

--- a/samples/system-test/delete_cluster.test.js
+++ b/samples/system-test/delete_cluster.test.js
@@ -16,7 +16,7 @@
 
 const {assert, expect} = require('chai');
 const {describe, it, after, before} = require('mocha');
-const randomUUID = require('uuid');
+const uuid = require('uuid');
 const cp = require('child_process');
 const container = require('@google-cloud/container');
 const untilDone = require('./test_util.js');
@@ -29,10 +29,8 @@ const zones = [
   'us-central1-f',
 ];
 const randomZone = zones[Math.floor(Math.random() * zones.length)];
-const randomClusterName = `nodejs-container-test-${randomUUID.v1().substring(
-  0,
-  8
-)}`;
+const randomUUID = uuid.v1().substring(0, 8);
+const randomClusterName = `nodejs-container-test-${randomUUID}`;
 const client = new container.v1.ClusterManagerClient();
 let projectId;
 let clusterLocation;

--- a/samples/system-test/quicktest.test.js
+++ b/samples/system-test/quicktest.test.js
@@ -14,11 +14,11 @@
 
 'use strict';
 
-const { assert } = require('chai');
-const { describe, it } = require('mocha');
+const {assert} = require('chai');
+const {describe, it} = require('mocha');
 const cp = require('child_process');
 
-const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 describe('container samples - quickstart', () => {
   it('should run the quickstart', async () => {

--- a/samples/system-test/quicktest.test.js
+++ b/samples/system-test/quicktest.test.js
@@ -14,13 +14,13 @@
 
 'use strict';
 
-const {assert} = require('chai');
-const {describe, it} = require('mocha');
+const { assert } = require('chai');
+const { describe, it } = require('mocha');
 const cp = require('child_process');
 
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
 
-describe('container samples', () => {
+describe('container samples - quickstart', () => {
   it('should run the quickstart', async () => {
     const stdout = execSync('node quickstart');
     assert.match(stdout, /Clusters:/);

--- a/samples/system-test/test_util.js
+++ b/samples/system-test/test_util.js
@@ -28,18 +28,18 @@ let currDelay;
  * from the approach we have for the samples itself. The samples use an async
  * function with delayed setIntervals. Since, the last function call of the
  * samples is the wait for the long running operation to complete, the program
- * waits until the delayed setInterval async functions resolves. 
- * 
+ * waits until the delayed setInterval async functions resolves.
+ *
  * However, when running the tests we have certain setup to be done in the
  * before() hook which are also long running operations. We would want to block
  * until these setup steps are fully complete before allowing for the tests to
  * start. If we use the same approach as used in the samples (with an async
  * function scheduled on setIntervals), the before() hook will not block. Rather
  * it will return and the tests will start running.
- * 
+ *
  * To prevent this scenario, we have employed a sleep based retry and wait
- * method below to be used only for the test cases. 
- * 
+ * method below to be used only for the test cases.
+ *
  * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
  * @param {string} opIdentifier the unique identifier of the operation we want to check
  */

--- a/samples/system-test/test_util.js
+++ b/samples/system-test/test_util.js
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const container = require('@google-cloud/container');
+const STATUS_ENUM = container.protos.google.container.v1.Operation.Status;
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const maxRetries = 20;
+let retryCount;
+let prevDelay;
+let currDelay;
+
+async function retryUntilDone(client, opIdentifier) {
+  retryCount = 0;
+  prevDelay = 0;
+  currDelay = 1000;
+
+  while (retryCount <= maxRetries) {
+    const [longRunningOp] = await client.getOperation({name: opIdentifier});
+    const status = longRunningOp.status;
+    if (status !== STATUS_ENUM[STATUS_ENUM.DONE]) {
+      const fibonacciDelay = prevDelay + currDelay;
+      prevDelay = currDelay;
+      currDelay = fibonacciDelay;
+      await sleep(fibonacciDelay);
+    } else {
+      break;
+    }
+    retryCount += 1;
+  }
+}
+
+module.exports = retryUntilDone;

--- a/samples/system-test/test_util.js
+++ b/samples/system-test/test_util.js
@@ -24,16 +24,16 @@ let prevDelay;
 let currDelay;
 
 /**
- * We use a custom wait and retry methos for the test cases, which is different
+ * We use a custom wait and retry method for the test cases, which is different
  * from the approach we have for the samples itself. The samples use an async
  * function with delayed setIntervals. Since, the last function call of the
  * samples is the wait for the long running operation to complete, the program
- * waits until the delayed setInterval async functions resolves. 
+ * waits until the delayed setInterval async functions resolve. 
  * 
  * However, when running the tests we have certain setup to be done in the
  * before() hook which are also long running operations. We would want to block
  * until these setup steps are fully complete before allowing for the tests to
- * start. If we use the same approach as used in the samples (with an async
+ * start. If we use the same approach used in the samples (with an async
  * function scheduled on setIntervals), the before() hook will not block. Rather
  * it will return and the tests will start running.
  * 

--- a/samples/system-test/test_util.js
+++ b/samples/system-test/test_util.js
@@ -23,6 +23,26 @@ let retryCount;
 let prevDelay;
 let currDelay;
 
+/**
+ * We use a custom wait and retry methos for the test cases, which is different
+ * from the approach we have for the samples itself. The samples use an async
+ * function with delayed setIntervals. Since, the last function call of the
+ * samples is the wait for the long running operation to complete, the program
+ * waits until the delayed setInterval async functions resolves. 
+ * 
+ * However, when running the tests we have certain setup to be done in the
+ * before() hook which are also long running operations. We would want to block
+ * until these setup steps are fully complete before allowing for the tests to
+ * start. If we use the same approach as used in the samples (with an async
+ * function scheduled on setIntervals), the before() hook will not block. Rather
+ * it will return and the tests will start running.
+ * 
+ * To prevent this scenario, we have employed a sleep based retry and wait
+ * method below to be used only for the test cases. 
+ * 
+ * @param {container.v1.ClusterManagerClient} client the google cloud API client used to submit the request
+ * @param {string} opIdentifier the unique identifier of the operation we want to check
+ */
 async function retryUntilDone(client, opIdentifier) {
   retryCount = 0;
   prevDelay = 0;

--- a/samples/system-test/test_util.js
+++ b/samples/system-test/test_util.js
@@ -28,8 +28,8 @@ let currDelay;
  * from the approach we have for the samples itself. The samples use an async
  * function with delayed setIntervals. Since, the last function call of the
  * samples is the wait for the long running operation to complete, the program
- * waits until the delayed setInterval async functions resolve. 
- * 
+ * waits until the delayed setInterval async functions resolve.
+ *
  * However, when running the tests we have certain setup to be done in the
  * before() hook which are also long running operations. We would want to block
  * until these setup steps are fully complete before allowing for the tests to


### PR DESCRIPTION
## Fixes #415 

### Description
- For a detailed description read internal ref [b/189985582](http://b/189985582)
- The Kubernetes engine API protos were written before the API Improvement Proposal [(AIP-151)](https://google.aip.dev/151)
- AIP-151 suggests to annotate API calls that takes a long time to complete with a certain annotation. This will enable the auto-generator _(that generates our client libraries)_ to wrap the response an object of type [google.longrunning.Operation](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc/google.longrunning) in a language native (Python Future or Nodejs Promise) async construct.
- However, since  AIP-151 came long after the container.v1 API protos were written, the container API protos don't have the necessary annotation as guided in AIP-151  
- As a result the auto generated **container client libraries** do not return the very useful [google.longrunning.Operation](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc/google.longrunning) object, instead they return [google.container.v1.Operation](https://cloud.google.com/nodejs/docs/reference/container/latest/container/protos.google.container.v1.operation-class)
- This object does not have the necessary built-ins to easily verify if the operation has completed. 
- This this PR adds a few samples to show to customers how they can use this Operation object to validate if their operation has successfully completed using **polling with backoff on the getOperation()** API

### Changes
- Added 2 samples _(create_cluster & delete_cluster)_ to showcase usage of the library and to show how to handle responses of type `google.container.v1.Operation`
- Upon creation we use a fibonacci backoff to retry until the operation is complete
- I have also added test cases for the added samples

### Testing
- Create a project
- Enable the container (GKE) API
- Create a service account with permissions to create/delete clusters _(can use Owner)_
- Download a key for the created service account

```bash
export GOOGLE_APPLICATION_CREDENTIALS="<PATH_TO_KEY>"
gcloud config set project <GCP_PROJECT>

cd <repo_path>
git checkout lro-fix

node samples/create_cluster.js --zone=us-central1-b --name=gke10
node samples/delete_cluster.js --zone=us-central1-b --name=gke10

npm run samples-test
```
  

