### PR TITLE
chore: Remove anthos-dpe from owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/anthos-dpe
+*     @googleapis/yoshi-nodejs
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs @googleapis/yoshi-nodejs
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,7 +8,6 @@
   "distribution_name": "@google-cloud/container",
   "requires_billing": true,
   "product_documentation": "https://cloud.google.com/kubernetes-engine",
-  "codeowner_team": "@googleapis/yoshi-nodejs",
   "name_pretty": "Kubernetes Engine Cluster Manager API",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/container/latest",
   "release_level": "stable",

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,7 +8,7 @@
   "distribution_name": "@google-cloud/container",
   "requires_billing": true,
   "product_documentation": "https://cloud.google.com/kubernetes-engine",
-  "codeowner_team": "@googleapis/anthos-dpe",
+  "codeowner_team": "@googleapis/yoshi-nodejs",
   "name_pretty": "Kubernetes Engine Cluster Manager API",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/container/latest",
   "release_level": "stable",


### PR DESCRIPTION
This PR removes `anthos-dpe` from the owners of this repository, as it's been fully handed over to the corresponding Yoshi team.

Related PRs:
- https://github.com/googleapis/java-container/pull/779
- https://github.com/googleapis/python-container/pull/285
- https://github.com/googleapis/nodejs-cloud-container/pull/563
- https://github.com/googleapis/google-cloud-java/pull/8271
- https://github.com/googleapis/google-cloud-node/pull/3324